### PR TITLE
fix: refine work/blog hovers, unify external-link seal, /now & social tweaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,6 @@ There is **no unit-test suite** — "testing" here means `task validate` / `task
 
 ## Architecture
 
-This is a hand-built Astro site (it was rebuilt off the AstroWind starter — that scaffolding,
-its config-driven `astrowind:config` integration, and `tailwind.config.js` are gone).
-
 - **Tailwind v4 is CSS-first.** There is **no** `@astrojs/tailwind` integration; it's the Vite
   plugin (`@tailwindcss/vite` in `astro.config.ts`) plus `@import "tailwindcss"` inside
   `src/styles/global.css`, imported once from `src/layouts/Layout.astro`.

--- a/src/components/almanac/ExternalSeal.astro
+++ b/src/components/almanac/ExternalSeal.astro
@@ -1,0 +1,15 @@
+---
+// ExternalSeal.astro — the gilt-circle outbound (↗) emblem that marks links
+// leaving the site. Place it as a direct child of the link; the parent's :hover
+// lifts it (see `.seal` / `a:hover > .seal` in global.css). It is the only arrow
+// these listings carry — there is no second horizontal →.
+---
+
+<span class="seal" aria-hidden="true">
+  <svg viewBox="0 0 24 24" width="14" height="14">
+    <g fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="7" y1="17" x2="16.5" y2="7.5"></line>
+      <polyline points="9.5,7 17,7 17,14.5"></polyline>
+    </g>
+  </svg>
+</span>

--- a/src/components/almanac/Projects.astro
+++ b/src/components/almanac/Projects.astro
@@ -3,6 +3,7 @@
 // closed with an inter-section flourish.
 import SectionAside from './SectionAside.astro';
 import Flourish from './Flourish.astro';
+import ExternalSeal from './ExternalSeal.astro';
 import { PROJECTS } from '~/data/site';
 ---
 
@@ -21,29 +22,11 @@ import { PROJECTS } from '~/data/site';
             >
               <div class="no">{i + 1}</div>
               <div>
-                <h3 class="display">
-                  {p.title}
-                  <span class="arw" aria-hidden="true">
-                    →
-                  </span>
-                </h3>
+                <h3 class="display">{p.title}</h3>
                 <p>{p.description}</p>
                 <div class="tag label">{p.kind}</div>
               </div>
-              <span class="seal" aria-hidden="true">
-                <svg viewBox="0 0 24 24" width="14" height="14">
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.7"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <line x1="7" y1="17" x2="16.5" y2="7.5" />
-                    <polyline points="9.5,7 17,7 17,14.5" />
-                  </g>
-                </svg>
-              </span>
+              {p.href.startsWith('http') && <ExternalSeal />}
             </a>
           ))
         }

--- a/src/components/almanac/SocialIcon.astro
+++ b/src/components/almanac/SocialIcon.astro
@@ -15,7 +15,8 @@ const LOGOS: Record<string, string> = {
   Memex: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.074 0C12.586 1.374 10.1 2.749 7.613 4.124l.823 4.266 6.365-5.015zm.172.059l-.269 3.314 4.497 2.752zm-.353 3.466L8.487 8.576l7.39 15.367 1.177-2.359L19.58 6.4c-.012-.009-4.688-2.875-4.688-2.875zm-7.425.779l-3.05 6.594L9.033 21.51l-.74-12.934-.012-.064zm1.025 4.688l.73 12.784L15.71 24Z"/></svg>`,
   'omg.lol': `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>`,
 };
-const GLYPHS: Record<string, string> = { Meetup: 'm' };
+// engraved-monogram fallback for any social without an SVG logo
+const GLYPHS: Record<string, string> = {};
 
 const svg = LOGOS[name];
 const glyph = GLYPHS[name];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -19,14 +19,13 @@ export const NAV: NavLink[] = [
   { label: 'Now', href: '/now' },
 ];
 
-export type SocialName = 'GitHub' | 'LinkedIn' | 'Bluesky' | 'Mastodon' | 'Meetup' | 'omg.lol' | 'Memex';
+export type SocialName = 'GitHub' | 'LinkedIn' | 'Bluesky' | 'Mastodon' | 'omg.lol' | 'Memex';
 
 export const SOCIALS: { name: SocialName; href: string }[] = [
   { name: 'GitHub', href: 'https://github.com/evanharmon1' },
   { name: 'LinkedIn', href: 'https://www.linkedin.com/in/evanharmon1' },
   { name: 'Bluesky', href: 'https://bsky.app/profile/evanharmon.com' },
   { name: 'Mastodon', href: 'https://mastodon.social/@evanharmon' },
-  { name: 'Meetup', href: 'https://www.meetup.com/kansas-city-tech-enthusiasts/' },
   { name: 'omg.lol', href: 'https://evanharmon.omg.lol' },
   { name: 'Memex', href: 'https://www.evanharmon.com/memex' },
 ];

--- a/src/pages/brand.astro
+++ b/src/pages/brand.astro
@@ -4,6 +4,7 @@
 import Layout from '~/layouts/Layout.astro';
 import Header from '~/components/almanac/Header.astro';
 import Footer from '~/components/almanac/Footer.astro';
+import ExternalSeal from '~/components/almanac/ExternalSeal.astro';
 
 // Palette swatches — hex + OKLCH, shown verbatim as a reference (the one place
 // raw values are intentionally on display).
@@ -432,26 +433,27 @@ const Swatches = (rows: Swatch[]) => rows;
                 <span class="bentry">
                   <div class="bno">1</div>
                   <div>
-                    <h4 class="display">Harmon Stack <span style="color:var(--accent)">→</span></h4>
+                    <h4 class="display">Harmon Stack</h4>
                     <p>
                       A project template to bootstrap &amp; streamline new work — CI/CD, security tests, linting, docs.
                     </p>
                     <div class="label" style="margin-top:.7rem;color:var(--accent)">Template · CI/CD</div>
                   </div>
-                  <span class="seal">❧</span>
+                  <ExternalSeal />
                 </span>
                 <span class="bentry">
                   <div class="bno">2</div>
                   <div>
-                    <h4 class="display">Harmon Ops <span style="color:var(--accent)">→</span></h4>
+                    <h4 class="display">Harmon Ops</h4>
                     <p>Scripts, dotfiles, automation &amp; IaC for a developer environment and homelab.</p>
                     <div class="label" style="margin-top:.7rem;color:var(--accent)">Infrastructure</div>
                   </div>
-                  <span class="seal">❧</span>
+                  <ExternalSeal />
                 </span>
               </div>
               <p class="note" style="margin-top:1rem">
-                Hover: tint + content slides inward. Numerals Playfair italic; ❧ seal top-right.
+                Hover: tint + content slides inward. Numerals Playfair italic. A single emblem only — the gilt ↗ seal,
+                top-right, marking links that leave the site (it lifts on hover); no second horizontal arrow.
               </p>
             </div>
           </div>
@@ -465,24 +467,23 @@ const Swatches = (rows: Swatch[]) => rows;
           <h2 class="sec-title display">Colour-block</h2>
         </div>
         <div class="block-body">
-          <p class="note">
+          <p class="note" style="margin-top:0">
             The only filled surfaces — green on light, blue on dark — always carrying gold foil ornaments &amp;
-            warm-white text.
+            warm-white text. The closing “Let's Talk” block below is the canonical example.
           </p>
+          <div class="bcta">
+            <div class="crest">❦</div>
+            <h3>Let's Talk</h3>
+            <p class="btag">Send a word</p>
+            <div class="btn-row" style="justify-content:center">
+              <a class="bbtn bbtn--invert" href="/contact">Contact Me</a>
+              <a class="bbtn bbtn--ghost" href="https://fantastical.app/evanharmon" target="_blank" rel="noopener"
+                >Meet With Me</a
+              >
+            </div>
+          </div>
         </div>
       </section>
-    </div>
-
-    <div class="bcta">
-      <div class="crest">❦</div>
-      <h3>Let's Talk</h3>
-      <p class="btag">Send a word</p>
-      <div class="btn-row" style="justify-content:center">
-        <a class="bbtn bbtn--invert" href="/contact">Contact Me</a>
-        <a class="bbtn bbtn--ghost" href="https://fantastical.app/evanharmon" target="_blank" rel="noopener"
-          >Meet With Me</a
-        >
-      </div>
     </div>
   </main>
   <Footer />
@@ -584,11 +585,10 @@ const Swatches = (rows: Swatch[]) => rows;
   .block-body {
     min-width: 0;
   }
-  /* numeral + title run vertically up the gutter, as on the homepage rail */
+  /* numeral + title run vertically down the gutter, as on the homepage rail */
   .block-rail {
     align-self: center;
     writing-mode: vertical-rl;
-    transform: rotate(180deg);
     white-space: nowrap;
     line-height: 1;
     display: flex;
@@ -891,12 +891,11 @@ const Swatches = (rows: Swatch[]) => rows;
     font-size: 0.96rem;
     line-height: 1.5;
   }
-  .bentry .seal {
-    position: absolute;
-    top: 1.4rem;
-    right: 1.4rem;
+  /* the external-link seal (global `.seal`) sits top-right; demo its hover lift */
+  .bentry:hover :global(.seal) {
     color: var(--accent);
-    opacity: 0.5;
+    border-color: color-mix(in oklab, var(--accent) 55%, transparent);
+    transform: translate(3px, -3px) scale(1.08);
   }
 
   /* brand & voice */

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,6 +3,7 @@ import Layout from '~/layouts/Layout.astro';
 import Header from '~/components/almanac/Header.astro';
 import Footer from '~/components/almanac/Footer.astro';
 import PageHeading from '~/components/almanac/PageHeading.astro';
+import ExternalSeal from '~/components/almanac/ExternalSeal.astro';
 import { MEET_URL } from '~/data/site';
 
 const ways = [
@@ -28,19 +29,15 @@ const ways = [
   <Header />
   <main class="section">
     <div class="wrap">
-      <PageHeading title="Contact" sub="An open correspondence" center />
+      <PageHeading title="Contact" sub="Open correspondence" center />
       <div class="ways">
         {
           ways.map((w) => (
             <a class="way" href={w.href} target={w.href.startsWith('http') ? '_blank' : undefined} rel="noopener">
-              <h3 class="display">
-                {w.title}
-                <span class="arw" aria-hidden="true">
-                  →
-                </span>
-              </h3>
+              <h3 class="display">{w.title}</h3>
               <div class="detail">{w.detail}</div>
               <p>{w.note}</p>
+              {w.href.startsWith('http') && <ExternalSeal />}
             </a>
           ))
         }
@@ -59,6 +56,7 @@ const ways = [
     border-top: 1px solid var(--color-line);
   }
   .way {
+    position: relative;
     display: block;
     padding: 1.6rem;
     border-bottom: 1px solid var(--color-line);
@@ -74,15 +72,6 @@ const ways = [
     font-size: var(--text-h3);
     font-weight: 600;
     margin: 0 0 0.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-  .way h3 .arw {
-    opacity: 0;
-    transform: translateX(-4px);
-    transition: all 0.25s ease;
-    color: var(--color-accent);
   }
   .way .detail {
     font-family: var(--font-numeral);
@@ -102,10 +91,6 @@ const ways = [
   }
   .way:hover h3 {
     color: var(--color-accent);
-  }
-  .way:hover h3 .arw {
-    opacity: 1;
-    transform: translateX(0);
   }
   @media (max-width: 860px) {
     .ways {

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -21,6 +21,13 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
           sizes="(max-width: 540px) 80vw, 420px"
           loading="eager"
         />
+        <figcaption class="now-figcap" role="tooltip">
+          <span class="cap-t">The Flammarion Engraving</span>
+          <span class="cap-d"
+            >Often interpreted as a symbol of curiosity, scientific discovery, or breaking through an old worldview.</span
+          >
+          <span class="cap-m">Artist unknown · 1888</span>
+        </figcaption>
       </figure>
 
       <p class="now-intro">
@@ -84,7 +91,15 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
 
         <h4>Making</h4>
         <ul>
-          <li>Building and upgrading my PCs</li>
+          <li>
+            Building and upgrading my PCs, <a
+              href="https://pcpartpicker.com/user/telosmachina/saved/#view=nDZXYJ"
+              target="_blank"
+              rel="noopener">Contraption</a
+            > and <a href="https://pcpartpicker.com/user/telosmachina/saved/#view=qjHqBm" target="_blank" rel="noopener"
+              >TARS</a
+            >
+          </li>
           <li>
             Building a <a
               href="https://the-diy-life.com/introducing-lab-rax-a-3d-printable-modular-10-rack-system/"
@@ -101,7 +116,8 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
             /now page and <a href="https://home.omg.lol/" target="_blank" rel="noopener">omg.lol</a>!)
           </li>
           <li><a href="https://astro.build/" target="_blank" rel="noopener">Astro Web Framework</a></li>
-          <li><a href="https://tanstack.com/" target="_blank" rel="noopener">TanStack</a></li>
+          <li><a href="https://tanstack.com/" target="_blank" rel="noopener">TanStack Application Framework</a></li>
+          <li><a href="https://www.convex.dev/" target="_blank" rel="noopener">Convex Platform</a></li>
           <li>Design</li>
         </ul>
 
@@ -115,7 +131,7 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
             >
           </li>
           <li>
-            <a href="https://www.youtube.com/watch?v=y115_2h4a68" target="_blank" rel="noopener"
+            <a href="https://youtu.be/tX1znPfzhVI?si=1kWgKNxDego3inZL" target="_blank" rel="noopener"
               >Jesse Morris: Sunday Morning Coming Down</a
             >
           </li>
@@ -123,7 +139,7 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
 
         <h3>Playing</h3>
         <ul>
-          <li>Arc Raiders</li>
+          <li><a href="https://arcraiders.com/" target="_blank" rel="noopener">Arc Raiders</a></li>
         </ul>
 
         <h3>Watching</h3>
@@ -137,8 +153,10 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
               >chunk a coal</a
             >
           </li>
-          <li>Widow's Bay</li>
-          <li>Scot Squad</li>
+          <li>
+            <a href="https://en.wikipedia.org/wiki/Widow%27s_Bay" target="_blank" rel="noopener">Widow's Bay</a>
+          </li>
+          <li><a href="https://en.wikipedia.org/wiki/Scot_Squad" target="_blank" rel="noopener">Scot Squad</a></li>
         </ul>
 
         <h3>Laughing</h3>
@@ -183,6 +201,7 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
     max-width: min(72ch, 92vw);
   }
   .now-figure {
+    position: relative;
     margin: 0 auto 1.6rem;
     max-width: 420px;
   }
@@ -194,6 +213,58 @@ import RuleOrn from '~/components/almanac/RuleOrn.astro';
     box-shadow:
       inset 0 0 0 3px var(--color-paper),
       inset 0 0 0 4px color-mix(in oklab, var(--color-rule) 45%, transparent);
+  }
+  /* floating label that fades in over the engraving on hover */
+  .now-figcap {
+    position: absolute;
+    left: 50%;
+    bottom: 0.85rem;
+    width: max-content;
+    max-width: min(90%, 22rem);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.7rem 1rem;
+    text-align: center;
+    background: color-mix(in oklab, var(--color-paper) 94%, transparent);
+    border: 1px solid var(--color-rule);
+    box-shadow:
+      inset 0 0 0 2px var(--color-paper),
+      0 8px 20px rgba(0, 0, 0, 0.22);
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, 8px);
+    transition:
+      opacity 0.22s ease,
+      transform 0.22s ease;
+  }
+  .now-figure:hover .now-figcap,
+  .now-figure:focus-within .now-figcap {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  .now-figcap .cap-t {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 1.3rem;
+    line-height: 1.1;
+    color: var(--color-ink);
+  }
+  .now-figcap .cap-d {
+    font-family: var(--font-body);
+    font-style: italic;
+    font-size: 1rem;
+    line-height: 1.45;
+    color: var(--color-ink-soft);
+  }
+  .now-figcap .cap-m {
+    font-family: var(--font-body);
+    font-variant: small-caps;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+    font-size: var(--text-label);
+    color: var(--color-ink-faint);
   }
   .now-intro {
     text-align: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -585,7 +585,6 @@
   .sec-aside {
     align-self: center;
     writing-mode: vertical-rl;
-    transform: rotate(180deg);
     white-space: nowrap;
     line-height: 1;
     display: flex;
@@ -693,7 +692,7 @@
     gap: 1.1rem;
     transition:
       background 0.25s ease,
-      padding 0.25s ease;
+      box-shadow 0.25s ease;
   }
   .catalog .entry:nth-child(odd) {
     border-right: 1px solid var(--color-line);
@@ -712,15 +711,8 @@
     font-size: var(--text-h3);
     margin: 0.1rem 0 0.4rem;
     font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-  .entry h3 .arw {
-    opacity: 0;
-    transform: translateX(-4px);
-    transition: all 0.25s ease;
-    color: var(--color-accent);
+    /* keep the title clear of the gilt seal in the top-right corner */
+    padding-right: 2.4rem;
   }
   .entry p {
     margin: 0;
@@ -731,19 +723,22 @@
   .entry .tag {
     margin-top: 0.7rem;
   }
+  /* hover marks the entry with a left accent keyline + tint — no padding change,
+     so the title never re-wraps or jumps */
   .entry:hover {
     background: color-mix(in oklab, var(--color-paper-2) 75%, transparent);
-    padding-left: 2.2rem;
+    box-shadow: inset 2px 0 0 var(--color-accent);
   }
   .entry:hover h3 {
     color: var(--color-accent);
   }
-  .entry:hover h3 .arw {
-    opacity: 1;
-    transform: translateX(0);
-  }
-  /* the catalog seal — a gilt circle with an outbound-link arrow */
-  .entry .seal {
+
+  /* ---- External-link seal ----
+     A gilt circle with an outbound (↗) arrow that marks links leaving the site.
+     Drop it in as a direct child of the link (the only arrow these listings
+     carry — no second horizontal →); the parent link's :hover lifts it. Shared
+     by the Work catalog, the Contact ways, and the Brand reference. */
+  .seal {
     position: absolute;
     top: 1.5rem;
     right: 1.5rem;
@@ -759,16 +754,17 @@
       inset 0 0 0 3px color-mix(in oklab, var(--color-gold) 18%, transparent);
     transition:
       color 0.25s ease,
-      transform 0.25s ease,
+      transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
       border-color 0.25s ease;
   }
-  .entry .seal svg {
+  .seal svg {
     display: block;
   }
-  .entry:hover .seal {
+  /* the link lifts the seal up-and-out on hover */
+  a:hover > .seal {
     color: var(--color-accent);
     border-color: color-mix(in oklab, var(--color-accent) 55%, transparent);
-    transform: translate(2px, -2px);
+    transform: translate(3px, -3px) scale(1.08);
   }
 
   /* ---- Blog — ledger ---- */
@@ -777,14 +773,16 @@
   }
   .ledger .row {
     display: grid;
-    grid-template-columns: 8.5rem 1fr auto;
+    /* fixed date + category columns so every title starts and wraps at the same
+       place (no row hugs the category to a different width) */
+    grid-template-columns: 8.5rem minmax(0, 1fr) 7rem;
     gap: 1.4rem;
     align-items: baseline;
-    padding: 1.15rem 0.4rem;
+    padding: 1.15rem 1rem;
     border-bottom: 1px solid var(--color-line);
     transition:
-      background 0.2s,
-      padding 0.2s;
+      background 0.2s ease,
+      box-shadow 0.2s ease;
   }
   .ledger .row:first-child {
     border-top: 1px solid var(--color-line);
@@ -818,9 +816,11 @@
     color: var(--color-accent);
     white-space: nowrap;
   }
+  /* hover marks the row with a left accent keyline + tint — no padding change,
+     so the title never re-wraps or jumps */
   .ledger .row:hover {
     background: color-mix(in oklab, var(--color-paper-2) 70%, transparent);
-    padding-inline: 1rem;
+    box-shadow: inset 2px 0 0 var(--color-accent);
   }
   .ledger .row:hover .t {
     color: var(--color-accent);


### PR DESCRIPTION
## Summary

Design polish across the homepage, `/contact`, `/brand`, and `/now`, plus small content/link fixes.

### Hover & arrow refinements
- **Work catalog & blog ledger:** the hover used to add inline padding, which narrowed the row and re-wrapped balanced titles across lines (jarring). Replaced with a non-reflowing **left accent keyline + tint**, so titles no longer move.
- Reserved space on the Work entry title so the gilt seal no longer overlaps it (e.g. "Sommer Lawn & Landscape").
- Added a shared **`ExternalSeal`** component + global `.seal`. The gilt ↗ emblem now marks **only links that leave the site** (Work, Contact ways, Brand specimens) and lifts on hover. Removed the redundant horizontal `→`.

### `/brand`
- Vertical section titles now read **top-to-bottom**, matching the homepage rail (the homepage's rotation was being overridden by the reveal animation; brand's wasn't).
- Moved the colour-block **"Let's Talk"** demo into **section No. 7** so its title heads real content.
- Catalog specimens reflect the new external-link seal.

### `/contact`
- "An open correspondence" → **"Open correspondence"**.

### `/now`
- Hover **tooltip** on the Flammarion engraving (title, interpretation line, "Artist unknown · 1888"), with legible sizing.
- New links: **Arc Raiders**, **Widow's Bay**, **Scot Squad**, **Contraption/TARS** (PCPartPicker), **Convex Platform**.
- Renamed **TanStack → TanStack Application Framework**; fixed the **Jesse Morris** link.

### Misc
- Removed the **Meetup** social link (and its now-unused type/glyph).

## Testing
- `pnpm build` ✓ (36 pages)
- `pnpm check` ✓ (0 errors, 0 warnings) — eslint + prettier clean
- Verified each change visually in the browser (hovers, tooltip, orientation, seals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)