### PR TITLE
chore: update to harmon-init v3.20.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,16 @@
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)"
+    ],
+    "ask": [
+      "Bash(gh pr merge)",
+      "Bash(gh pr merge:*)",
+      "Bash(git merge)",
+      "Bash(git merge:*)",
+      "Bash(git push origin main)",
+      "Bash(git push origin main:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force:*)"
     ]
   }
 }

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,9 +1,10 @@
 # Changes here will be overwritten by Copier
-_commit: v3.16.0
+_commit: v3.20.0
 _src_path: https://github.com/evanharmon1/harmon-init
 bunch_add: false
 ci_runner: ubuntu-latest
 code_owner: evanharmon1
+deploy_cloudflare_workers: true
 devcontainer: true
 git_init: false
 github_org: evanharmon1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ permissions:
 
 jobs:
   lint:
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -70,7 +72,9 @@ jobs:
       - run: task test:devcontainer:permissions
 
   build-test:
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -104,7 +108,9 @@ jobs:
         run: task test
 
   security:
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -138,7 +144,9 @@ jobs:
         run: task security
 
   lighthouse:
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -242,7 +250,9 @@ jobs:
   verify:
     if: always()
     needs: [lint, security, build-test, lighthouse]
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     steps:
       - name: Check job results
         run: |

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -22,7 +22,9 @@ jobs:
        contains(github.event.issue.body, '@claude implement') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-implement'))
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 180
     permissions:
       contents: write

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -22,7 +22,9 @@ jobs:
        contains(github.event.issue.body, '@claude plan') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-plan'))
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 120
     permissions:
       contents: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,7 +23,9 @@ jobs:
        contains(github.event.review.body, '@claude review') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-review'))
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/close-milestone-on-release.yml
+++ b/.github/workflows/close-milestone-on-release.yml
@@ -13,7 +13,9 @@ permissions:
 jobs:
   close-milestone:
     name: Close matching milestone
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 10
     steps:
       - name: Close the milestone named after the tag

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,9 @@ jobs:
       vars.FULL_SECURITY_SCAN == 'true' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 30
     permissions:
       actions: read
@@ -51,7 +53,9 @@ jobs:
   codeql-verify:
     if: always()
     needs: [analyze]
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     steps:
       - name: Check analyze result
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,158 @@
+name: Deploy Preview
+run-name: deploy preview for PR #${{ github.event.pull_request.number }}
+
+# Cloudflare deploys run from GitHub Actions via wrangler-action against the
+# evanharmon-site Worker (static assets — wrangler.jsonc). Every same-repo
+# PR uploads a non-production Worker *version* bound to the `preview` GitHub
+# Environment: a unique versioned preview URL plus a stable branch-alias URL,
+# both on workers.dev. Versions never receive live traffic; production
+# deploys happen in release.yml when a release-please release PR merges.
+#
+# Requires the Worker to exist (first created by the bootstrap/production
+# deploy in release.yml — see that file's workflow_dispatch trigger).
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Fork PRs have no secrets, and until CLOUDFLARE_API_TOKEN is configured the
+  # deploy should skip rather than fail. Secrets are not readable in job-level
+  # `if:` expressions, so a tiny preflight job exposes the check as an output.
+  preflight:
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - name: Check Cloudflare credentials
+        id: check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "CLOUDFLARE_API_TOKEN is not available (fork PR or secret not yet configured) — skipping preview deploy." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  deploy:
+    needs: preflight
+    if: needs.preflight.outputs.configured == 'true'
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # renovate: datasource=node-version
+          node-version: "24"
+          cache: pnpm
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+          version: 3.51.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: task build
+      # github.head_ref is attacker-influenced (branch names may contain `;`,
+      # `$`, backticks) and the wrangler-action command runs through a shell,
+      # so reduce it to a safe preview alias: lowercase [a-z0-9-], no
+      # leading/trailing dash, short enough that alias + "-evanharmon-site"
+      # fits in a 63-char DNS label.
+      - name: Derive preview alias from branch name
+        id: branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          alias=$(printf '%s' "$HEAD_REF" \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr -c 'a-z0-9-' '-' \
+            | tr -s '-' \
+            | sed -e 's/^-//' -e 's/-$//' \
+            | cut -c1-40)
+          echo "alias=$alias" >> "$GITHUB_OUTPUT"
+      - name: Upload preview version to Cloudflare Workers
+        id: deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: pnpm
+          # renovate: datasource=npm depName=wrangler
+          wranglerVersion: "4.107.0"
+          command: >-
+            versions upload
+            --preview-alias=${{ steps.branch.outputs.alias }}
+            --message=pr-${{ github.event.pull_request.number }}
+      - name: Comment preview URLs on PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          COMMAND_OUTPUT: ${{ steps.deploy.outputs.command-output }}
+          PREVIEW_ALIAS: ${{ steps.branch.outputs.alias }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const deployUrl = process.env.DEPLOY_URL
+            // wrangler-action only surfaces the versioned preview URL as an
+            // output; fish the stable branch-alias URL out of wrangler's
+            // stdout.
+            const alias = process.env.PREVIEW_ALIAS
+            const aliasUrl = (process.env.COMMAND_OUTPUT || '')
+              .match(/https:\/\/[a-z0-9.-]+\.workers\.dev/g)
+              ?.find(u => u.includes(`//${alias}-`)) ?? null
+            const body = [
+              '## Cloudflare Workers Preview',
+              '',
+              '| | URL |',
+              '|---|---|',
+              `| **Preview (this version)** | ${deployUrl} |`,
+              aliasUrl ? `| **Branch alias** | ${aliasUrl} |` : null,
+              '',
+              `_Deployed commit: ${process.env.HEAD_SHA}_`,
+            ].filter(l => l !== null).join('\n')
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.startsWith('## Cloudflare Workers Preview')
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              })
+            }

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -20,7 +20,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -95,7 +97,9 @@ jobs:
   devcontainer-verify:
     if: always()
     needs: [build]
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     steps:
       - name: Check job results
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,32 @@
 name: Release Please
-run-name: release-please maintaining the release PR
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+    && format('manual production deploy of {0}', github.ref_name)
+    || 'release-please maintaining the release PR' }}
 
 # Releases stay intentional: release-please maintains a rolling release PR from
 # conventional commits (feat -> minor, fix -> patch; pre-1.0 feat bumps minor;
 # chore/docs/ci produce no release). Merging that PR — a deliberate act — is
 # what creates the tag, GitHub release, and CHANGELOG entry. Nothing is bumped
 # automatically on a normal merge to main.
+#
+# Production deploys are release-first: when release-please cuts a release,
+# the deploy-production job builds the tagged commit and runs `wrangler
+# deploy` against the evanharmon-site Worker (static assets —
+# wrangler.jsonc). Gating on the step output — instead of chaining
+# `on: release` / `on: deployment_status` — avoids the GitHub limitation that
+# events created by GITHUB_TOKEN never trigger workflows.
+#
+# workflow_dispatch deploys the selected ref directly (release-please is
+# skipped). Two uses: the one-time bootstrap deploy that creates the Worker
+# before any release exists, and rollback — dispatch the workflow from the
+# previous release tag to redeploy it.
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: release-please
@@ -21,11 +37,17 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: [ "ubuntu-latest" ]
+    if: github.event_name == 'push'
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       # CI GitHub App token, not GITHUB_TOKEN: PRs opened by GITHUB_TOKEN never
       # trigger CI, and branch protection requires those checks to pass before
@@ -42,5 +64,64 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+
+  deploy-production:
+    needs: release-please
+    # Runs when release-please created a release, or on manual dispatch
+    # (bootstrap/rollback) where release-please is skipped — hence
+    # !cancelled() so the skipped `needs` doesn't auto-skip this job.
+    if: >-
+      !cancelled() && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.release-please.outputs.release_created == 'true'
+      )
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    environment:
+      name: production
+      # TODO: add `url: https://<your-domain>` once the custom domain exists.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Tag from release-please on release runs; the dispatched ref on
+          # manual runs.
+          ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # renovate: datasource=node-version
+          node-version: "24"
+          cache: pnpm
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+          version: 3.51.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: task build
+      - name: Deploy to Cloudflare Workers (production)
+        id: deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: pnpm
+          # renovate: datasource=npm depName=wrangler
+          wranglerVersion: "4.107.0"
+          command: deploy
+      - name: Summarize deployment
+        env:
+          DEPLOYED_REF: ${{ needs.release-please.outputs.tag_name || github.ref_name }}
+        run: |
+          {
+            echo "## Production deployment"
+            echo ""
+            echo "- Ref: \`$DEPLOYED_REF\` (${{ github.event_name }})"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ node_modules/
 # Git worktrees
 .worktrees/
 
+# Design-handoff bundles (Claude Design exports) live as specs/ subdirectories
+# while being implemented and are deleted at sign-off — never committed.
+# Top-level specs/*.md (README, _template, feature specs) stay tracked.
+specs/*/
+
 # Lefthook local overrides (not committed)
 .lefthook-local.yml
 
@@ -77,6 +82,9 @@ screenshots/
 # coverage / test output
 coverage/
 .nyc_output/
+
+# Lighthouse CI output
+.lighthouseci/
 
 # Devcontainer env files (injected locally via 1Password, never committed)
 .devcontainer/**/devcontainer.env

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,6 +21,8 @@ dist/
 .terraform/
 .venv/
 pnpm-lock.yaml
+# Design-handoff bundles under specs/ (vendored Claude Design exports).
+specs/*/
 
 # release-please owns CHANGELOG.md (writes double blanks Prettier would strip).
 CHANGELOG.md

--- a/.yamllint
+++ b/.yamllint
@@ -4,6 +4,7 @@ extends: default
 ignore:
   - node_modules/
   - dist/
+  - specs/*/
   - .astro/
   - .task/
   - .worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,19 @@ Repo: https://github.com/evanharmon1/evanharmon-site — see [docs/README.md](do
 documentation map, [docs/architecture/README.md](docs/architecture/README.md)
 for the architecture, and [DESIGN.md](DESIGN.md) for design/UX intent.
 
+## Hard Rules
+
+Non-negotiable, regardless of any autonomy granted elsewhere in this file:
+
+- **Never write to a password manager or credential store unprompted.** Do not
+  create, modify, archive, or delete anything in 1Password (items, fields,
+  vaults — via the `op` CLI or any other means), OS keychains, or any other
+  secret store unless the user explicitly requested that specific write in the
+  current conversation. Even when asked, restate exactly what will be written
+  and get confirmation before executing — announcing intent and proceeding in
+  the same turn is not consent. Read operations (`op read`, `op item list`,
+  `op inject` over existing references) are fine.
+
 ## Commands
 
 All repo-level commands go through the Taskfile (single source of truth — CI,
@@ -59,6 +72,10 @@ utilities, and static WCAG AA token contrast (`test/check-contrast.mjs`).
   refactor, revert, style, test).
 - Never bypass git hooks (`--no-verify` is forbidden); fix the underlying issue.
 - Work on a feature branch; direct commits to `main` are blocked.
+- **Never merge to main yourself** — no `gh pr merge`, `git merge`, or push to
+  `main` without the maintainer's explicit, per-merge approval, even when CI is
+  green and the ruleset would allow it. Open the PR, report that checks pass,
+  then stop; merging is always a human decision.
 - Releases are intentional: release-please keeps a rolling release PR from
   conventional commits; merging it cuts the tag/release. Nothing bumps on a
   normal merge. `task release:*` remains as a manual override.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -117,7 +117,7 @@ tasks:
         if [ -n "{{.CLI_ARGS}}" ]; then
           npx --yes markdownlint-cli2 {{.CLI_ARGS}}
         else
-          npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
+          npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' '#specs/*/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
         fi
 
   lint:actions:
@@ -197,6 +197,8 @@ tasks:
   validate:links:
     desc: Check the built site (dist/) for broken internal links (lychee, offline)
     cmds:
+      # --root-dir is required to resolve root-relative links (/about, /rss.xml)
+      # against dist/ instead of failing with "provide a root dir".
       - lychee --offline --no-progress --root-dir "{{.PWD}}/dist" ./dist
 
   guard:no-commit-to-main:

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -91,8 +91,21 @@ config, toolchain, devcontainer, and dev environment — against the items below
       pnpm 10+ silently ignores that field, so overrides declared there vanish on
       the next lockfile resolve
 - [ ] Review `lighthouserc.json` URLs once routes exist
+- [ ] Enable mobile device projects in `playwright.config.ts` (e.g. Pixel +
+      iPhone) — the Playwright scaffold ships them commented out, and
+      mobile-first is the convention
 
 ## 4. Secrets & environment
+
+- [ ] Cloudflare Workers deploys: create an **Account API Token** scoped to
+      **Account → Workers Scripts → Edit** only (1-year TTL + renewal
+      reminder) and add it: `gh secret set CLOUDFLARE_API_TOKEN`. The
+      `CLOUDFLARE_ACCOUNT_ID` org-level Actions variable is shared org-wide —
+      set it once per org if missing.
+- [ ] Create the `preview` and `production` GitHub Environments (production:
+      restrict to protected branches). Then bootstrap the Worker: Actions →
+      *Release Please* → *Run workflow* (main) — the first `wrangler deploy`
+      creates it; PR preview uploads work from that point.
 
 - [ ] For local `.env` needs, use **1Password Environments** (mounts a virtual
       `.env`; secrets never hit disk or git) or `op run`/`op inject`. Commit only

--- a/docs/architecture/tests.md
+++ b/docs/architecture/tests.md
@@ -15,4 +15,7 @@ How testing works in Evan Harmon Website.
 
 - Test files live in `tests/` at the repo root (or co-located per framework convention).
 - `task verify` is the local merge gate; CI runs the same task targets.
+- Playwright runs desktop Chromium/Firefox/WebKit **and mobile device
+  projects** (e.g. Pixel + iPhone). The scaffold ships the mobile projects
+  commented out — enable them; mobile-first is the convention.
 - TODO: document coverage expectations and fixtures as the suite grows.

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -4,7 +4,29 @@ How to deploy Evan Harmon Website. For the shape of the CI/CD pipeline see
 [../architecture/ci-cd.md](../architecture/ci-cd.md); for production operational
 procedures and rollback runbooks see [../runbooks/](../runbooks/).
 
-> TODO: no deployment is configured yet — fill in the sections below.
+The site is served by the `evanharmon-site` **Cloudflare Worker** (static
+assets, configured in [`wrangler.jsonc`](../../wrangler.jsonc)). All deploys
+run from GitHub Actions via `cloudflare/wrangler-action`. Custom domains are
+managed outside wrangler (Terraform `cloudflare_workers_custom_domain`, or the
+dashboard).
+
+- **Preview**: every same-repo PR uploads a non-production Worker *version*
+  (`deploy-preview.yml`) — versioned + branch-alias URLs on workers.dev,
+  posted as a sticky PR comment. Preview versions never receive production
+  traffic. Skips gracefully when `CLOUDFLARE_API_TOKEN` is unavailable.
+- **Production**: merging the release-please release PR makes `release.yml`
+  build the tagged commit and run `wrangler deploy`. Normal merges to `main`
+  do **not** deploy production.
+- **Bootstrap / rollback**: Actions → *Release Please* → *Run workflow* with a
+  branch or tag deploys that ref directly — used once to create the Worker,
+  and to redeploy the previous release tag.
+
+Credentials: `CLOUDFLARE_ACCOUNT_ID` is an org-level Actions **variable** (an
+identifier, not a secret); `CLOUDFLARE_API_TOKEN` is a repo **secret** — an
+Account API Token scoped to **Account → Workers Scripts → Edit** only, 1-year
+TTL with a renewal reminder (rotate via the token's Roll button + re-run
+`gh secret set CLOUDFLARE_API_TOKEN`). Also create `preview` and `production`
+GitHub Environments (see the post-generation CHECKLIST).
 
 ## Environments
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,7 @@ export default [
     },
   },
   {
-    ignores: ['dist', 'node_modules', '.github', 'types.generated.d.ts', '.astro', 'docs/design'],
+    // specs/ holds vendored design-handoff bundles (deleted at sign-off).
+    ignores: ['dist', 'node_modules', '.github', 'types.generated.d.ts', '.astro', 'docs/design', 'specs'],
   },
 ];

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,8 +16,10 @@ pre-commit:
     prettier:
       glob: "*.{js,jsx,ts,tsx,astro,md,mdx,json,jsonc,yml,yaml,css,scss,html}"
       # CLAUDE.md / GEMINI.md / copilot-instructions.md are symlinks to AGENTS.md,
-      # and the .meta note is a symlink into the Obsidian vault; prettier errors
-      # when a symlink is passed explicitly (traversal during `--check .` skips them).
+      # and a v2-era `.meta/*.md` note may be a symlink into the Obsidian vault
+      # (obsidian_project_add moved the file and left a link); prettier errors
+      # when a symlink is passed explicitly (traversal during `--check .` skips
+      # them).
       exclude:
         - CLAUDE.md
         - GEMINI.md

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -11,7 +11,7 @@
     "assert": {
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.7 }],
-        "categories:accessibility": ["error", { "minScore": 0.85 }],
+        "categories:accessibility": ["error", { "minScore": 1 }],
         "categories:best-practices": ["error", { "minScore": 0.7 }],
         "categories:seo": ["error", { "minScore": 0.9 }]
       }

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       "description": "Workflow tool pins, `version:` style",
       "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+version:\\s*(?<currentValue>\\S+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+version:\\s*(?<currentValue>\\S+)",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+wranglerVersion:\\s*\"(?<currentValue>[^\"]+)\""
       ]
     },
     {

--- a/scripts/lint-hygiene.sh
+++ b/scripts/lint-hygiene.sh
@@ -8,6 +8,12 @@
 #
 # Usage: ./scripts/lint-hygiene.sh [file ...]
 #   If no files given, checks all tracked files.
+#
+# Per-file exemptions: an optional repo-root .lint-hygiene-ignore lists one
+# path or glob per line ('#' comments and blank lines allowed); matching files
+# are skipped entirely. Reserve it for app-managed configs the app rewrites on
+# its own terms (e.g. karabiner.json dropping the final newline) — it is not a
+# general lint escape hatch.
 set -euo pipefail
 
 errors=0
@@ -26,9 +32,36 @@ else
     done < <(git ls-files --cached --others --exclude-standard 2>/dev/null)
 fi
 
+# Load per-file exemption patterns (bash 3.2 compatible)
+ignore_patterns=()
+if [ -f .lint-hygiene-ignore ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        '' | '#'*) continue ;;
+        esac
+        ignore_patterns+=("$line")
+    done <.lint-hygiene-ignore
+fi
+
+is_ignored() {
+    # Empty-array guard: "${arr[@]}" on an empty array is an unbound-variable
+    # error under `set -u` in bash 3.2.
+    [ "${#ignore_patterns[@]}" -eq 0 ] && return 1
+    local p pat
+    p="$1"
+    for pat in "${ignore_patterns[@]}"; do
+        # shellcheck disable=SC2254  # unquoted on purpose: glob match
+        case "$p" in
+        $pat) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 for f in "${files[@]}"; do
     [ -f "$f" ] || continue
     [ -L "$f" ] && continue # skip symlinks (AGENTS.md aliases etc.)
+    if is_ignored "$f"; then continue; fi
 
     # Skip binary files and known binary extensions
     case "$f" in

--- a/scripts/validate-jsonld.mjs
+++ b/scripts/validate-jsonld.mjs
@@ -50,7 +50,8 @@ for (const file of pages) {
     const nodes = Array.isArray(data) ? data : data['@graph'] || [data];
     const ctx = data['@context'] || nodes.find((n) => n && n['@context'])?.['@context'];
     // @context may be a string or an array of strings/objects; anchor the match
-    // to the schema.org origin (a bare substring test would accept lookalike hosts).
+    // to the schema.org origin (a bare substring test would accept lookalike hosts
+    // — flagged by CodeQL as js/incomplete-url-substring-sanitization).
     const ctxStrings = (Array.isArray(ctx) ? ctx : [ctx]).filter((s) => typeof s === 'string');
     if (!ctxStrings.some((s) => /^https?:\/\/(www\.)?schema\.org([/#]|$)/i.test(s.trim()))) {
       console.error(`FAIL [${label}] JSON-LD missing a schema.org @context`);

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,3 +14,11 @@ against. (Specs cover *what* and *why*; `docs/architecture/` covers *how*, and
    acceptance criteria.
 3. Keep one spec per feature/change; link it from the implementing PR, and
    update or supersede it as the work evolves.
+
+## Design-handoff bundles
+
+Claude Design exports (the `design-handoff` skill's input) are unpacked into
+**subdirectories** here — `specs/handoff-<feature>/`. They are vendored,
+temporary reference material: ignored by git and every linter (`specs/*/` in
+the ignore configs) and **deleted at sign-off**, never committed. Top-level
+`specs/*.md` spec files stay tracked and linted as usual.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,23 @@
+// Cloudflare Workers (static assets) configuration. The worker is assets-only
+// (no script): it serves the build output from dist/, including any _headers
+// and _redirects files copied from public/.
+//
+// Deploys run from GitHub Actions (deploy-preview.yml uploads preview
+// versions, release.yml runs `wrangler deploy` on releases). Manage custom
+// domains outside this file (Terraform cloudflare_workers_custom_domain, or
+// the dashboard) so wrangler owns only the Worker itself.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "evanharmon-site",
+  // Bump deliberately when adopting new runtime behavior.
+  "compatibility_date": "2026-07-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page",
+  },
+  // No workers.dev production URL (the site lives on its custom domain), but
+  // keep per-version preview URLs for PR deploys — workers_dev: false would
+  // otherwise disable them by default.
+  "workers_dev": false,
+  "preview_urls": true,
+}


### PR DESCRIPTION
Updates evanharmon-site from harmon-init **v3.16.0 → v3.20.0** via `copier update`.

## What changed (template delta)

- **v3.17.0** — no-merge-to-main + password-manager Hard Rules in `AGENTS.md`; `.claude/settings.json` merge guards; design-handoff `specs/` shield (eslint + markdownlint ignore `specs/`); web-astro validator hardening (JSON-LD schema.org origin anchoring, lychee `--root-dir`).
- **v3.18.0** — `.lint-hygiene-ignore` support in `scripts/lint-hygiene.sh`; `.gitignore` adds `.lighthouseci/`; a11y gate raised to 1.0 (`lighthouserc.json`).
- **v3.18.1** — lefthook prettier excludes `.meta/*.md` vault symlinks.
- **v3.19.0** — runtime `CI_RUNS_ON` runner switch across all workflows; **deployment strategy upstreamed** (see below).
- **v3.20.0** — no-unprompted-password-manager-writes hard rule.

## New: Cloudflare deploy strategy (v3.19.0 #229)

The template now ships the proven web-astro deploy flow, so this update **adds**:
- `.github/workflows/deploy-preview.yml` — per-PR Cloudflare Worker preview versions.
- `wrangler.jsonc` — Worker static-assets config.
- `release.yml` production-deploy steps (on release-please release merge).
- `docs/guides/deploying.md` refresh.

**CI-safe as-is:** `deploy-preview.yml` has a `preflight` job that **skips** the deploy when `CLOUDFLARE_API_TOKEN` is unset (fork PRs have no secrets). It only deploys once the Worker + `CLOUDFLARE_API_TOKEN` are configured — no action required to merge, but that config is the follow-up to actually enable previews/prod deploys.

## Reconciliation (4 conflicts, all resolved by hand)

- **`scripts/validate-jsonld.mjs`** / **`eslint.config.js`** — add/add where the template generalized what this repo pioneered. Kept the repo's versions (its `.prettierrc.cjs` uses `semi: true`, so the template's semicolon-free generic copy would fail the repo's own prettier); grafted the template's CodeQL-reference comment, and folded `specs/` into the repo's existing eslint `ignores` block (no duplicate block).
- **`lefthook.yml`** / **`Taskfile.yml`** — took the template's improved comments (symlink-prettier note; lychee `--root-dir` rationale).
- Silent-revert cross-check: `summarize-gitleaks.mjs`, `.markdownlint-cli2.jsonc`, `commitlint.config.mjs` confirmed **unchanged** (customizations preserved).
- `prettier.config.cjs` reads as `MISSING` in diff-template — intentional: repo uses `.prettierrc.cjs`. Left as-is (no dead second config).

## ⚠️ Security-relevant setting (called out)

`.claude/settings.json` gains `permissions.ask` merge/force-push guards — a hardening (confirmation gates only).

## Verification (local)

- `task verify` ✅ (astro build + JSON-LD/responsive/links validators + task/hook tests) · `task security` ✅ (gitleaks: no leaks) · `verify-applied.sh` ✅ PASS
- No conflict markers remain. (One transient `prettier --check .` temp-file race during `verify-applied`; green on re-run — noted upstream as a web-astro `.prettierignore` hardening candidate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
