### PR TITLE
chore: configure devcontainer related repos

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
   "permissions": {
+    "additionalDirectories": [
+      "../harmon-init",
+      "../harmon-devkit",
+      "../harmon-dotfiles",
+      "../harmon-ops"
+    ],
     "allow": [
       "Bash(task:*)",
       "Bash(git status:*)",
@@ -16,5 +22,15 @@
       "Bash(git push -f:*)",
       "Bash(git push --force:*)"
     ]
+  },
+  "sandbox": {
+    "filesystem": {
+      "allowRead": [
+        "../harmon-init",
+        "../harmon-devkit",
+        "../harmon-dotfiles",
+        "../harmon-ops"
+      ]
+    }
   }
 }

--- a/.devcontainer/related-repos.txt
+++ b/.devcontainer/related-repos.txt
@@ -18,6 +18,9 @@
 # tools) AND sandbox.filesystem.allowRead (the Bash sandbox). See
 # docs/guides/devcontainers.md.
 #
-# Examples — uncomment and edit:
-#   your-org/shared-libs
-#   your-org/api@main
+# Harmon platform sibling repositories. These are cloned into /workspaces/
+# alongside evanharmon-site when the devcontainer is created.
+https://github.com/evanharmon1/harmon-init
+https://github.com/evanharmon1/harmon-devkit
+https://github.com/evanharmon1/harmon-dotfiles
+https://github.com/evanharmon1/harmon-ops


### PR DESCRIPTION
## Description

Configures the existing related-repository manifest to clone harmon-init, harmon-devkit, harmon-dotfiles, and harmon-ops alongside evanharmon-site. Claude project and Bash-sandbox read permissions match the cloned sibling directories.

## Type of change

- [x] Task / chore (maintenance, tooling, no product change)

## How Has This Been Tested?

- [x] `task verify`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes