### PR TITLE
chore: update to harmon-init v4.1.1

### DIFF
--- a/.claude/skills/.SKILLS_PROVENANCE
+++ b/.claude/skills/.SKILLS_PROVENANCE
@@ -1,6 +1,6 @@
 # VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
 # source: https://github.com/evanharmon1/harmon-devkit.git
-# ref: v0.7.0 (64b6dc3cf6c8297e06f76737ccacc0ebd179a56c)
+# ref: v0.7.2 (29f815debc79e2126d7a6268f9c5ae16923c10f2)
 # path: ai/skills
 # categories: universal, frontend
 # managed: design-handoff

--- a/.claude/skills/design-handoff/references/ingesting-the-bundle.md
+++ b/.claude/skills/design-handoff/references/ingesting-the-bundle.md
@@ -32,10 +32,11 @@ preferred path:
 
 ```bash
 task ingest:design BUNDLE=<bundle>.tar.gz   # validates entries (no absolute/.. /link paths), then extracts to specs/
-# manual equivalent — the listing grep MUST come back empty before any tar -xzf:
-tar -tzf <bundle>.tar.gz | grep -E '^/|(^|/)\.\.(/|$)'   # any hit → refuse to extract
-tar -xzf <bundle>.tar.gz -C specs/
 ```
+
+Do not replace this task with raw `tar` or `unzip` commands. If the target repo does not yet have
+the task, first copy `assets/ingest-design.sh` to `scripts/ingest-design.sh` and merge
+`assets/Taskfile.design.yml` into its Taskfile, as described in the skill setup, then run the task.
 
 It extracts to a single project directory. Move/rename it to `specs/handoff-<feature>/` — do this
 **even when the user pre-placed it under another name**: consistent naming is what the repo's ignore

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v4.0.0
+_commit: v4.1.1
 _src_path: https://github.com/evanharmon1/harmon-init
 bunch_add: false
 ci_runner: ubuntu-latest
@@ -20,11 +20,16 @@ project_management: github
 project_name: Evan Harmon Website
 project_slug: evanharmon-site
 project_type: web-astro
+release_content_paths: ''
 run_task_install: false
 skill_categories:
 - universal
 - frontend
 snyk_scan_schedule: 'off'
 use_foreman: true
+use_codeql: true
+codeql_languages:
+- javascript-typescript
+- python
 use_release_please: true
 use_skills_sync: true

--- a/.foreman.toml
+++ b/.foreman.toml
@@ -14,6 +14,10 @@ max_parallel = 3
 branch_prefix = "foreman"
 expected_login = "evanharmon1-bot"
 
+# Only these GitHub logins, trusted author associations, and Foreman's own
+# account may contribute unresolved review-thread content to agent prompts.
+review_sender_trust = ["coderabbitai", "Copilot"]
+
 # subscription (default): adapters inherit CLAUDE_CODE_OAUTH_TOKEN; USD
 # budgets are inert (guardrails bind on timeout/turns). api: adapters export
 # FOREMAN_ANTHROPIC_API_KEY process-locally; USD budgets bind.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Lint + typecheck
         run: task check
       - run: task test:tasks
+      - run: task test:release-title
       - run: task foreman:test
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
         run: task verify:skills
@@ -228,19 +229,43 @@ jobs:
     # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
     # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    env:
+      IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
-      - name: Check job results
+      # Never check out or run fork-controlled repository code on this path.
+      - name: Verify deliberate skips at the untrusted-fork boundary
+        if: env.IS_FORK == 'true'
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+          BUILD_TEST_RESULT: ${{ needs.build-test.result }}
+          LIGHTHOUSE_RESULT: ${{ needs.lighthouse.result }}
         run: |
           fail=0
-          check() {
-            [ "$2" = "success" ] || [ "$2" = "skipped" ] || { echo "Job $1 result: $2"; fail=1; }
+          check_skipped() {
+            if [ "$2" != "skipped" ]; then
+              echo "Job $1 result: $2 (expected skipped for an untrusted fork)"
+              fail=1
+            fi
           }
-          check lint "${{ needs.lint.result }}"
-          check security "${{ needs.security.result }}"
-          check build-test "${{ needs.build-test.result }}"
-          check lighthouse "${{ needs.lighthouse.result }}"
+          check_skipped lint "$LINT_RESULT"
+          check_skipped security "$SECURITY_RESULT"
+          check_skipped build-test "$BUILD_TEST_RESULT"
+          check_skipped lighthouse "$LIGHTHOUSE_RESULT"
           if [ "$fail" -ne 0 ]; then
-            echo "One or more required jobs failed."
             exit 1
           fi
-          echo "All required jobs passed."
+          echo "Untrusted fork trust boundary enforced: all repository-controlled jobs were deliberately skipped."
+      - if: env.IS_FORK != 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Verify required jobs succeeded
+        if: env.IS_FORK != 'true'
+        env:
+          EXPECTED_RESULT: success
+          LINT_RESULT: ${{ needs.lint.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+          BUILD_TEST_RESULT: ${{ needs.build-test.result }}
+          LIGHTHOUSE_RESULT: ${{ needs.lighthouse.result }}
+        run: ./scripts/verify-required-results.sh "lint=${LINT_RESULT}" "security=${SECURITY_RESULT}" "build-test=${BUILD_TEST_RESULT}" "lighthouse=${LIGHTHOUSE_RESULT}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
       matrix:
         language:
           - javascript-typescript
+          - python
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -59,25 +60,44 @@ jobs:
     # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
     # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          persist-credentials: false
       - name: Check analyze result
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          FULL_SECURITY_SCAN: ${{ github.event.repository.private == false && 'true' || vars.FULL_SECURITY_SCAN }}
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
+        run: ./scripts/verify-codeql-result.sh
+      # Never check out or execute fork-controlled repository code on the
+      # aggregate runner. The workflow-defined fork diagnostic stays inline.
+      - name: Check deliberate fork skip
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          FULL_SECURITY_SCAN: ${{ github.event.repository.private == false && 'true' || vars.FULL_SECURITY_SCAN }}
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
         run: |
-          result="${{ needs.analyze.result }}"
-          required=true
-          if [ "${{ github.event.repository.private }}" = "true" ] && \
-             [ "${{ vars.FULL_SECURITY_SCAN }}" != "true" ]; then
-            required=false
-          fi
-          if [ "${{ github.event_name }}" = "pull_request" ] && \
-             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            required=false
-          fi
-          if [ "$required" = "true" ] && [ "$result" != "success" ]; then
-            echo "CodeQL analysis is required but result was: $result"
+          scan="${FULL_SECURITY_SCAN:-false}"
+          case "$scan" in
+            true | false) ;;
+            *)
+              echo "Invalid FULL_SECURITY_SCAN value: $scan"
+              exit 1
+              ;;
+          esac
+          if [ "$ANALYZE_RESULT" != "skipped" ]; then
+            echo "CodeQL analyze result on fork: $ANALYZE_RESULT (expected skipped)"
             exit 1
           fi
-          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-            echo "CodeQL analyze result: $result"
-            exit 1
-          fi
-          echo "CodeQL analyze: $result (required: $required)"
+          echo "CodeQL analyze deliberately skipped for an untrusted fork."

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -102,12 +102,27 @@ jobs:
     # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
     # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    env:
+      IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
-      - name: Check job results
+      # Never check out or run fork-controlled repository code on this path.
+      - name: Verify deliberate skip at the untrusted-fork boundary
+        if: env.IS_FORK == 'true'
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
         run: |
-          result="${{ needs.build.result }}"
-          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-            echo "Devcontainer build failed."
+          if [ "$BUILD_RESULT" != "skipped" ]; then
+            echo "Job build result: $BUILD_RESULT (expected skipped for an untrusted fork)"
             exit 1
           fi
-          echo "Devcontainer build passed."
+          echo "Untrusted fork trust boundary enforced: the repository-controlled devcontainer build was deliberately skipped."
+      - if: env.IS_FORK != 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Verify devcontainer build succeeded
+        if: env.IS_FORK != 'true'
+        env:
+          EXPECTED_RESULT: success
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: ./scripts/verify-required-results.sh "build=${BUILD_RESULT}"

--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -9,7 +9,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.7.0 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.7.2 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - universal
   - frontend

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,9 +47,9 @@ tasks:
   ci:
     # Full local mirror of the CI pipeline — run before (or instead of) opening
     # a PR to catch everything CI would, on demand, without waiting on a PR run.
-    # Builds on `verify` and adds the heavier / environment-dependent checks
-    # (the devcontainer permission assert needs a Docker daemon, like CI has).
-    desc: Full CI mirror (verify → [test:devcontainer:permissions →] security)
+    # Builds on `verify` and adds the devcontainer permission assertion plus the
+    # heavier security checks.
+    desc: Full CI mirror (verify → test:devcontainer:permissions → security)
     cmds:
       - task: verify
       - task: test:devcontainer:permissions
@@ -59,14 +59,14 @@ tasks:
     # The definition-of-done gate — everything that must pass before a change
     # is done. Foreman v2 calls this the "check + build + test" tier; the desc
     # below lists this repo's exact steps. For the fast inner loop use `check`;
-    # heavier environment-dependent checks (security, the devcontainer
-    # permission assert) stay in `ci`.
+    # heavier security checks and the devcontainer permission assertion stay in `ci`.
     desc: Definition-of-done gate (check → build → validate → guards → test)
     cmds:
       - task: check
       - task: build
       - task: validate
       - task: test:tasks
+      - task: test:release-title
       - task: foreman:test
       - task: test:hooks
       - task: test
@@ -344,6 +344,11 @@ tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)
     cmds:
       - ./scripts/test-tasks.sh
+
+  test:release-title:
+    desc: Unit-test the release-content title guard (require-release-title.sh)
+    cmds:
+      - ./scripts/test-release-title.sh
 
   test:devcontainer:root:
     desc: Smoke test the primary (AI bot) devcontainer via the devcontainers CLI

--- a/docs/architecture/foreman.md
+++ b/docs/architecture/foreman.md
@@ -15,8 +15,8 @@ progression. Zero tokens are spent on coordination.
 
 - **No AI ever merges to main. Ever.** No auto-merge, no enabling flag. The
   human merge is the only mechanism that advances the dependency graph;
-  foreman's job ends at "this PR is verified, adjudicated, and mergeable —
-  here is the suggested merge order." Server-side enforcement (branch
+  foreman's job ends at "this PR is verified, adjudicated, and has GitHub
+  `mergeStateStatus=CLEAN` — here is the suggested merge order." Server-side enforcement (branch
   ruleset, code-owner review, bot token without bypass) is the boundary;
   prompts are only a mitigation.
 - **Stateless in the repo.** Human inputs are stored (issue bodies, labels /
@@ -150,9 +150,9 @@ Deterministic triggers → bounded agent actions on open foreman PRs:
   (commit + reply + resolve) or decline with technical reasoning (bots are
   sometimes wrong; deterministic facts beat speculation). Blanket-accepting
   is prohibited. Foreman re-checks disposition completeness afterwards.
-- **Green + adjudicated + mergeable** → `ready-to-merge` label plus a
-  dependency-aware suggested merge order. Foreman performs no merge action
-  of any kind.
+- **Green + adjudicated + `mergeStateStatus=CLEAN`** → `ready-to-merge` label
+  plus a dependency-aware suggested merge order. Foreman performs no merge
+  action of any kind.
 
 ## Watch mode and unattended runs
 
@@ -194,11 +194,19 @@ USD budgets bind. Switching is a config flip plus one secret.
   or reopen issues, edit issue bodies/titles, touch human comments, or write
   fields/types/dependency edges — those operations do not exist in the
   module, and the test suite greps to keep them absent.
-- **Prompt-injection surface**: only trusted-association comments enter
-  prompts; review-bot findings and CI logs are framed as claims to
+- **Prompt-injection surface**: only trusted-association issue comments and
+  review threads whose authors match a trusted association, Foreman's account,
+  or `review_sender_trust` enter prompts. Other unresolved review threads go to
+  the human queue. Trusted review-bot findings and CI logs are framed as claims to
   adjudicate, not instructions; agents run with conservative permission
   modes outside the sandboxed bot devcontainer (`FOREMAN_SANDBOXED=1`
   relaxes inside it).
+- **Backend environment**: agent subprocesses receive an explicit runtime and
+  authentication allowlist, not the complete parent environment. Dispatch,
+  CI-repair, rebase, and preflight agents do not receive `GH_TOKEN`; only the
+  adjudication agent receives the intentionally scoped bot token needed for its
+  reply-and-resolve contract. Cloud, 1Password, SSH-agent, and unrelated host
+  credentials never cross the adapter boundary.
 
 ## Configuration (.foreman.toml)
 
@@ -212,6 +220,7 @@ branch_prefix = "foreman"
 expected_login = "your-bot"   # identity assertion; "" skips
 billing = "subscription"      # subscription | api
 sandboxed = false             # FOREMAN_SANDBOXED=1 env inside the bot container
+review_sender_trust = ["coderabbitai", "Copilot"]
 
 [budgets]
 dispatch_usd = 20.0           # binds in api billing mode

--- a/scripts/foreman/backend.py
+++ b/scripts/foreman/backend.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import signal
 import subprocess
 import time
@@ -30,6 +31,48 @@ from foreman.config import Config
 from foreman.util import ForemanError, run, tail, utc_now_iso, write_text
 
 BACKENDS_DIR = Path(__file__).resolve().parent / "backends"
+BACKEND_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+# Process/runtime settings required by the adapter and Claude CLI. Secrets are
+# added conditionally below; arbitrary parent credentials never cross the
+# backend boundary.
+BACKEND_ENV_ALLOWLIST = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "LANG",
+        "TERM",
+        "COLORTERM",
+        "NO_COLOR",
+        "FORCE_COLOR",
+        "TZ",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "NODE_EXTRA_CA_CERTS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+        "FOREMAN_READONLY",
+        "FOREMAN_MOCK_STATUS",
+        "FOREMAN_MOCK_FILE",
+    }
+)
 
 RESULT_STATUSES = ("completed", "blocked")
 
@@ -48,13 +91,43 @@ class BackendResult:
 
 
 def adapter_path(name: str) -> Path:
-    path = BACKENDS_DIR / f"{name}.sh"
-    if not path.exists():
+    backends_dir = BACKENDS_DIR.resolve()
+    path = (backends_dir / f"{name}.sh").resolve()
+    if (
+        BACKEND_NAME_RE.fullmatch(name) is None
+        or path.parent != backends_dir
+        or not path.is_file()
+    ):
         available = sorted(p.stem for p in BACKENDS_DIR.glob("*.sh"))
         raise ForemanError(
             f"unknown backend '{name}' (available: {', '.join(available)})"
         )
     return path
+
+
+def backend_environment(cfg: Config, *, allow_github: bool = False) -> dict[str, str]:
+    """Least-privilege environment for a backend subprocess."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in BACKEND_ENV_ALLOWLIST or key.startswith("LC_")
+    }
+    if cfg.billing == "api":
+        api_key = os.environ.get("FOREMAN_ANTHROPIC_API_KEY", "")
+        if not api_key:
+            raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
+        env["FOREMAN_ANTHROPIC_API_KEY"] = api_key
+    else:
+        oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+        if oauth_token:
+            env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+    # Adjudication alone needs the scoped bot credential to reply and resolve.
+    # Dispatch, CI repair, rebase, and preflight agents never receive it.
+    if allow_github:
+        gh_token = os.environ.get("GH_TOKEN", "")
+        if gh_token:
+            env["GH_TOKEN"] = gh_token
+    return env
 
 
 def capabilities(adapter: Path) -> set[str]:
@@ -92,6 +165,7 @@ def run_backend(
     prompt_file: Path,
     timeout_min: int,
     resume_ref: str | None = None,
+    allow_github: bool = False,
 ) -> BackendResult:
     session_file = unit_run_dir / "session"
     log_file = unit_run_dir / "agent.log"
@@ -100,7 +174,7 @@ def run_backend(
     if result_file.exists():
         result_file.unlink()
 
-    env = os.environ.copy()
+    env = backend_environment(cfg, allow_github=allow_github)
     env.update(
         {
             "FOREMAN_PROMPT_FILE": str(prompt_file),
@@ -113,9 +187,6 @@ def run_backend(
             "FOREMAN_MAX_TURNS": str(cfg.max_turns),
         }
     )
-    if cfg.billing == "api" and not env.get("FOREMAN_ANTHROPIC_API_KEY"):
-        raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
-
     argv = [str(adapter), "resume", resume_ref] if resume_ref else [str(adapter), "run"]
     timed_out = False
     with stdout_file.open("a", encoding="utf-8") as out_fh:

--- a/scripts/foreman/config.py
+++ b/scripts/foreman/config.py
@@ -32,6 +32,9 @@ class Config:
     comment_trust: list[str] = field(
         default_factory=lambda: ["OWNER", "MEMBER", "COLLABORATOR"]
     )
+    review_sender_trust: list[str] = field(
+        default_factory=lambda: ["coderabbitai", "Copilot"]
+    )
     branch_prefix: str = "foreman"
     worktrees_dir: str = ".worktrees/foreman"
     runtime_dir: str = ".foreman"

--- a/scripts/foreman/github.py
+++ b/scripts/foreman/github.py
@@ -23,7 +23,7 @@ import json
 from typing import Any, Callable
 
 from foreman.config import Config
-from foreman.util import ForemanError, run, warn
+from foreman.util import ForemanError, run
 
 Runner = Callable[[list[str], str | None], tuple[int, str, str]]
 
@@ -71,7 +71,7 @@ query($owner: String!, $name: String!, $number: Int!) {
           isOutdated
           path
           comments(first: 50) {
-            nodes { author { login } body url }
+            nodes { author { login } authorAssociation body url }
           }
         }
       }
@@ -271,11 +271,21 @@ class GitHub:
                 f"number={number}",
             ]
         )
+        if not isinstance(out, dict) or out.get("errors"):
+            raise ForemanError(
+                f"review threads: indeterminate GraphQL response for PR #{number}"
+            )
         try:
-            return out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
-        except (KeyError, TypeError):
-            warn(f"review threads: unexpected GraphQL shape for PR #{number}")
-            return []
+            nodes = out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        except (KeyError, TypeError) as exc:
+            raise ForemanError(
+                f"review threads: unexpected GraphQL shape for PR #{number}"
+            ) from exc
+        if not isinstance(nodes, list) or not all(
+            isinstance(thread, dict) for thread in nodes
+        ):
+            raise ForemanError(f"review threads: invalid thread list for PR #{number}")
+        return nodes
 
     def branch_exists_remote(self, branch: str) -> bool:
         return self.gh.ok(["api", f"repos/{self.repo_slug()}/branches/{branch}"])

--- a/scripts/foreman/graph.py
+++ b/scripts/foreman/graph.py
@@ -218,7 +218,17 @@ def dependency_satisfied(
         return Doneness(False, "open")
 
     marked_prs = foreman_prs_for_issue(gh, cfg, number)
-    if marked_prs and not (inputs is not None and inputs.external):
+    external = inputs is not None and inputs.external
+    if not external:
+        if not marked_prs:
+            return Doneness(
+                False,
+                "closed, but no foreman PR satisfies the merge chain",
+                warnings=[
+                    f"#{number}: closed managed issue has no foreman-marked PR — "
+                    "resolve manually, mark foreman:satisfied, or mark foreman:external"
+                ],
+            )
         expected_author = cfg.expected_login or gh.viewer()
         default_branch = gh.default_branch()
         for pr in marked_prs:

--- a/scripts/foreman/shepherd.py
+++ b/scripts/foreman/shepherd.py
@@ -8,7 +8,7 @@ Deterministic triggers → bounded agent actions:
                 ones go to the agent (rebase additively, re-verify, push)
   unresolved review-bot threads → resume the agent to adjudicate each finding
                 (apply or decline-with-reasoning; blanket-accepting prohibited)
-  green ∧ adjudicated ∧ mergeable ∧ not behind → label ready-to-merge and
+  green ∧ adjudicated ∧ mergeStateStatus=CLEAN → label ready-to-merge and
                 report a dependency-aware suggested merge order.
 
 Foreman never merges. `gh run rerun` is assumed unavailable to the bot token;
@@ -92,6 +92,35 @@ def classify_checks(rollup: list[dict] | None) -> tuple[str, list[dict]]:
     return "green", []
 
 
+def trusted_review_threads(
+    gh: GitHub, cfg: Config, threads: list[dict]
+) -> tuple[list[dict], int]:
+    """Threads safe to embed in prompts + count requiring human handling."""
+    kept: list[dict] = []
+    excluded = 0
+    viewer = gh.viewer().casefold()
+    trusted_senders = {login.casefold() for login in cfg.review_sender_trust}
+    trusted_associations = set(cfg.comment_trust)
+    for thread in threads:
+        comments = (thread.get("comments") or {}).get("nodes") or []
+        safe = bool(comments)
+        for comment in comments:
+            author = (comment.get("author") or {}).get("login", "")
+            association = comment.get("authorAssociation", "")
+            if (
+                association not in trusted_associations
+                and author.casefold() != viewer
+                and author.casefold() not in trusted_senders
+            ):
+                safe = False
+                break
+        if safe:
+            kept.append(thread)
+        else:
+            excluded += 1
+    return kept, excluded
+
+
 def _failure_text(gh: GitHub, failed: list[dict]) -> str:
     parts = []
     for ctx in failed[:5]:
@@ -131,6 +160,8 @@ def _resume_agent(
     work: PrWork,
     prompt_name: str,
     tokens: dict[str, str],
+    *,
+    allow_github: bool = False,
 ) -> backend_mod.BackendResult:
     run_dir = backend_mod.unit_dir(cfg, root, work.unit_number)
     prompt = spec.load_prompt(prompt_name, tokens)
@@ -163,6 +194,7 @@ def _resume_agent(
         prompt_file=prompt_file,
         timeout_min=cfg.shepherd_timeout_min,
         resume_ref=resume_ref,
+        allow_github=allow_github,
     )
 
 
@@ -287,7 +319,8 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             work.state, work.detail = "escalated", "agent could not resolve the rebase"
         return work
 
-    threads = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    unresolved = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    threads, excluded_threads = trusted_review_threads(gh, cfg, unresolved)
     if threads:
         work.actions += 1
         rendered = []
@@ -301,7 +334,15 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             )
         tokens = _common_tokens(gh, cfg, work)
         tokens["THREADS"] = "\n".join(rendered)
-        result = _resume_agent(gh, cfg, root, work, "shepherd-adjudicate", tokens)
+        result = _resume_agent(
+            gh,
+            cfg,
+            root,
+            work,
+            "shepherd-adjudicate",
+            tokens,
+            allow_github=True,
+        )
         wt_path = _ensure_worktree(
             cfg, root, work.unit_number, work.branch, remote_name
         )
@@ -319,7 +360,15 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             ]
             if remaining:
                 work.state = "escalated"
-                work.detail = f"{len(remaining)} review thread(s) still undispositioned"
+                if excluded_threads:
+                    work.detail = (
+                        f"{excluded_threads} review thread(s) from untrusted authors "
+                        f"require human handling; {len(remaining)} total still undispositioned"
+                    )
+                else:
+                    work.detail = (
+                        f"{len(remaining)} review thread(s) still undispositioned"
+                    )
             else:
                 work.state, work.detail = (
                     "adjudicated",
@@ -329,12 +378,19 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             work.state, work.detail = "escalated", "adjudication agent failed"
         return work
 
-    mergeable = (status.get("mergeable") or "").upper()
-    if merge_state == "CLEAN" or mergeable == "MERGEABLE":
+    if excluded_threads:
+        work.state = "escalated"
+        work.detail = (
+            f"{excluded_threads} unresolved review thread(s) from untrusted authors "
+            "require human handling"
+        )
+        return work
+
+    if merge_state == "CLEAN":
         gh.label_own_pr(work.number, add=["ready-to-merge"])
         work.state, work.detail = (
             "ready",
-            "green, adjudicated, mergeable — awaiting human merge",
+            "green, adjudicated, mergeState=CLEAN — awaiting human merge",
         )
     else:
         work.state, work.detail = "healthy", f"mergeState={merge_state or 'UNKNOWN'}"

--- a/scripts/require-release-title.sh
+++ b/scripts/require-release-title.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# require-release-title.sh — fail a PR whose squash-merge title would silently
+# skip a release even though the PR changes release-worthy content.
+#
+# Why: PRs are squash-merged and release-please reads ONLY the squash commit
+# subject — which GitHub sets from the PR title for a multi-commit PR. A
+# non-releasing title (chore/docs/ci/…) on a content change therefore merges
+# with NO tag cut, so downstream consumers pinning a released tag never receive
+# the change. This guard makes that loud at PR time instead of silent at merge
+# time. See docs/conventions.md ("Releases").
+#
+# Usage:
+#   PR_TITLE="<title>" [PR_BODY="…"] \
+#   [CHANGED_FILES=$'a\nb'  |  BASE_SHA=<sha> [HEAD_SHA=<sha>]] \
+#     require-release-title.sh PREFIX [PREFIX …]
+#
+# PREFIXes are release-worthy path prefixes: a literal directory that matches
+# itself and everything beneath it (so `ai/skills` matches `ai/skills/x`, but
+# NOT the sibling `ai/skills-extra`). Changed files come from $CHANGED_FILES
+# (newline-separated) when set, else from `git diff --name-only BASE...HEAD`.
+# A title is "releasing" iff its type is feat/fix, or it marks a breaking
+# change (`!` before the colon, or a BREAKING CHANGE note in the body).
+#
+# Exit: 0 = ok (releasing title, or no release-worthy path touched, or no
+#       prefixes configured), 1 = violation, 2 = usage error.
+set -euo pipefail
+
+# No prefixes configured -> the guard is inert (a repo that has not opted in).
+if [ "$#" -eq 0 ]; then
+    echo "require-release-title: no release-worthy path prefixes configured — nothing to guard"
+    exit 0
+fi
+
+title="${PR_TITLE:-}"
+[ -n "$title" ] || {
+    echo "require-release-title: PR_TITLE is empty (set it to the PR title)" >&2
+    exit 2
+}
+
+# is_releasing_title TITLE BODY — 0 when the title would cut a release.
+is_releasing_title() {
+    _rt_title="$1"
+    _rt_body="${2:-}"
+    # The conventional "type(scope)!" prefix is everything before the FIRST colon;
+    # a title with no colon has no type line (only the body can declare breaking).
+    case "$_rt_title" in
+    *:*) _rt_head="${_rt_title%%:*}" ;;
+    *) _rt_head="" ;;
+    esac
+    # Breaking change: a `!` immediately before that first colon (feat!:, fix(api)!:).
+    # Matching a bare "!:" anywhere would let `chore: … !: …` bypass the guard.
+    case "$_rt_head" in
+    *"!") return 0 ;;
+    esac
+    # Breaking change footer in the body.
+    case "$_rt_body" in
+    *"BREAKING CHANGE"* | *"BREAKING-CHANGE"*) return 0 ;;
+    esac
+    # Leading conventional type (feat/fix), before an optional (scope).
+    _rt_type="${_rt_head%%(*}"
+    case "$_rt_type" in
+    feat | fix) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+if is_releasing_title "$title" "${PR_BODY:-}"; then
+    echo "require-release-title: title is a releasing type — ok: ${title}"
+    exit 0
+fi
+
+# Non-releasing title: only a problem if the PR touches release-worthy content.
+if [ -n "${CHANGED_FILES+x}" ]; then
+    files="$CHANGED_FILES"
+else
+    [ -n "${BASE_SHA:-}" ] || {
+        echo "require-release-title: set CHANGED_FILES, or BASE_SHA for a git diff" >&2
+        exit 2
+    }
+    files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA:-HEAD}")"
+fi
+
+matched=""
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    for prefix in "$@"; do
+        prefix="${prefix%/}" # tolerate a configured prefix written as "dir/"
+        case "$f" in
+        "$prefix" | "$prefix"/*)
+            matched="${matched}  - ${f}"$'\n'
+            break
+            ;;
+        esac
+    done
+done <<EOF
+${files}
+EOF
+
+if [ -z "$matched" ]; then
+    echo "require-release-title: no release-worthy paths changed — ok: ${title}"
+    exit 0
+fi
+
+paths_joined="$*"
+cat >&2 <<EOF
+require-release-title: this PR changes release-worthy content, but its title
+
+    ${title}
+
+is not a releasing type. Squash-merge uses the PR title as the commit subject,
+and release-please only cuts a release for feat / fix / breaking changes — so as
+titled, this would merge WITHOUT a release and downstream consumers pinning a
+released tag would never receive it.
+
+Release-worthy paths changed:
+${matched}
+Fix: retitle the PR with a releasing type —
+    fix: …    (patch)      feat: …    (minor)      feat!: …    (major, breaking)
+or, if this genuinely should not release, keep the change out of these prefixes:
+    ${paths_joined}
+EOF
+exit 1

--- a/scripts/run-semgrep.sh
+++ b/scripts/run-semgrep.sh
@@ -7,11 +7,12 @@ set -euo pipefail
 # renovate: datasource=pypi depName=semgrep
 SEMGREP_VERSION=1.170.0
 
+# Semgrep defaults to the current directory when no target is provided. Do not
+# append one here: callers can scope local scans with `task security:sast -- <path>`.
 exec uvx --from "semgrep==${SEMGREP_VERSION}" semgrep scan \
     --config p/default \
     --metrics=off \
     --error \
     --severity ERROR \
     --exclude=.worktrees \
-    "$@" \
-    .
+    "$@"

--- a/scripts/secret-set-1p.sh
+++ b/scripts/secret-set-1p.sh
@@ -42,12 +42,13 @@ command -v jq >/dev/null 2>&1 || fail "jq is required"
 # 1Password item JSON from the pipeline.
 exec 3<&0
 
-op item get "$item" --vault "$vault" --format json --reveal |
-    jq \
-        --arg field "$field" \
-        --arg section "$section" \
-        --rawfile secret /dev/fd/3 \
-        '
+updated_item="$(
+    op item get "$item" --vault "$vault" --format json --reveal |
+        jq \
+            --arg field "$field" \
+            --arg section "$section" \
+            --rawfile secret /dev/fd/3 \
+            '
         def secret_value:
           $secret | sub("\r?\n$"; "");
 
@@ -71,7 +72,7 @@ op item get "$item" --vault "$vault" --format json --reveal |
         # field carrying a structured (object) value — plain STRING/CONCEALED
         # fields are scalars, so an object value marks a passkey/SSH-key/document
         # credential we must not touch.
-        | if (.category == "SSHKEY" or .category == "PASSKEY")
+        | if (.category == "SSH_KEY" or .category == "SSHKEY" or .category == "PASSKEY")
              or (([.fields[] | select((.value | type) == "object")] | length) > 0) then
             error("item holds a passkey or SSH key; refusing full-item edit (op would clobber it)")
           else
@@ -90,7 +91,10 @@ op item get "$item" --vault "$vault" --format json --reveal |
           else
             (.fields[] |= if field_matches then .value = $value else . end)
           end
-        ' |
+        '
+)"
+printf '%s\n' "$updated_item" |
     op item edit "$item" --vault "$vault" >/dev/null
+unset updated_item
 
 echo "Updated 1Password item '$item' field '$field'."

--- a/scripts/test-release-title.sh
+++ b/scripts/test-release-title.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test-release-title.sh — unit-test require-release-title.sh: a content change
+# under a non-releasing title fails; releasing titles and non-content chores
+# pass; path-prefix matching respects the `/` boundary. Run via
+# `task test:release-title`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+guard="./scripts/require-release-title.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# run TITLE CHANGED_FILES PREFIX... -> echoes the guard's exit code.
+run() {
+    _t="$1"
+    _c="$2"
+    shift 2
+    _rc=0
+    PR_TITLE="$_t" CHANGED_FILES="$_c" "$guard" "$@" >/dev/null 2>&1 || _rc=$?
+    echo "$_rc"
+}
+
+echo "==> content change under a chore title fails"
+[ "$(run 'chore: update to harmon-init v4.0.0' "$(printf 'ai/skills/repo/x.md\nREADME.md')" ai/skills templates scripts)" = 1 ] ||
+    fail "chore + skill change should fail"
+
+echo "==> the same content change under a fix title passes"
+[ "$(run 'fix(standardize-repo): publish skill updates' 'ai/skills/repo/x.md' ai/skills templates scripts)" = 0 ] ||
+    fail "fix + skill change should pass"
+
+echo "==> a feat title passes"
+[ "$(run 'feat: add a skill' 'ai/skills/new.md' ai/skills)" = 0 ] || fail "feat should pass"
+
+echo "==> a breaking-change (!) chore-shaped title passes"
+[ "$(run 'refactor!: drop a skill' 'ai/skills/old.md' ai/skills)" = 0 ] || fail "! breaking should pass"
+
+echo "==> a stray '!:' later in a chore title does NOT bypass the guard"
+[ "$(run 'chore: update docs !: not breaking' 'ai/skills/x.md' ai/skills)" = 1 ] ||
+    fail "a bare !: elsewhere in the title must not count as breaking"
+
+echo "==> BREAKING CHANGE in the body passes even with a chore title"
+_rc=0
+PR_TITLE='chore: x' PR_BODY='BREAKING CHANGE: removed foo' CHANGED_FILES='ai/skills/x.md' \
+    "$guard" ai/skills >/dev/null 2>&1 || _rc=$?
+[ "$_rc" = 0 ] || fail "BREAKING CHANGE body should pass"
+
+echo "==> a chore touching only non-content paths passes"
+[ "$(run 'chore: tidy docs' "$(printf 'docs/x.md\nREADME.md')" ai/skills templates scripts)" = 0 ] ||
+    fail "chore without content change should pass"
+
+echo "==> docs is non-releasing: docs title touching a guarded path fails"
+[ "$(run 'docs(standardize-repo): tweak' 'ai/skills/repo/x.md' ai/skills)" = 1 ] ||
+    fail "docs + guarded content should fail"
+
+echo "==> a nested file under a prefix matches"
+[ "$(run 'chore: x' 'templates/scriptTemplates/shellScriptTemplate.sh' templates)" = 1 ] ||
+    fail "nested file under templates should match"
+
+echo "==> prefix boundary: a sibling dir sharing a name prefix does NOT match"
+[ "$(run 'chore: x' 'ai/skills-extra/x.md' ai/skills)" = 0 ] ||
+    fail "ai/skills-extra must not match the ai/skills prefix"
+
+echo "==> a configured prefix written with a trailing slash still matches"
+[ "$(run 'chore: x' 'templates/x.sh' templates/)" = 1 ] ||
+    fail "a trailing-slash prefix (templates/) must still match templates/x.sh"
+
+echo "==> an unconventional title with a content change fails"
+[ "$(run 'update the skills' 'ai/skills/x.md' ai/skills)" = 1 ] ||
+    fail "unconventional title + content change should fail"
+
+echo "==> no prefixes configured is inert (exit 0)"
+[ "$(run 'chore: x' 'ai/skills/x.md')" = 0 ] || fail "no prefixes should be inert"
+
+echo "==> an empty title is a usage error (exit 2)"
+_rc=0
+PR_TITLE='' CHANGED_FILES='ai/skills/x.md' "$guard" ai/skills >/dev/null 2>&1 || _rc=$?
+[ "$_rc" = 2 ] || fail "empty title should be a usage error"
+
+echo "release-title guard: all cases passed"

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -18,6 +18,9 @@ fail() {
     exit 1
 }
 
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+
 echo "==> Taskfile compiles (every task parses)"
 if ! task --list-all >/dev/null 2>&1; then
     fail "task --list-all failed — the Taskfile does not compile"
@@ -30,6 +33,23 @@ if command -v brew >/dev/null 2>&1; then
     fi
 else
     echo "    (skipped: brew not on PATH)"
+fi
+
+echo "==> Semgrep wrapper preserves explicit scan targets"
+semgrep_bin="${test_tmp}/semgrep-bin"
+semgrep_args="${test_tmp}/semgrep-args"
+mkdir -p "$semgrep_bin"
+cat >"${semgrep_bin}/uvx" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"${SEMGREP_ARGS:?}"
+EOF
+chmod +x "${semgrep_bin}/uvx"
+PATH="${semgrep_bin}:${PATH}" SEMGREP_ARGS="$semgrep_args" \
+    ./scripts/run-semgrep.sh scripts
+[ "$(tail -n 1 "$semgrep_args")" = "scripts" ] ||
+    fail "Semgrep wrapper did not preserve the explicit target"
+if grep -Fxq . "$semgrep_args"; then
+    fail "Semgrep wrapper appended a repository-wide target"
 fi
 
 echo "==> secret helper tasks reject missing destination metadata"
@@ -55,5 +75,45 @@ case "$out" in
 *"NAME and REPO are required"*) ;;
 *) fail "task secret:set:gh failed for the wrong reason: $out" ;;
 esac
+
+echo "==> 1Password helper rejects SSH Key categories at runtime"
+op_bin="${test_tmp}/op-bin"
+op_edit_called="${test_tmp}/op-edit-called"
+mkdir -p "$op_bin"
+cat >"${op_bin}/op" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+"item get")
+    printf '{"category":"%s","fields":[{"label":"password","type":"CONCEALED","value":"old"}]}\n' \
+        "${OP_FIXTURE_CATEGORY:?}"
+    ;;
+"item edit")
+    : >"${OP_EDIT_CALLED:?}"
+    cat >/dev/null
+    ;;
+*)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${op_bin}/op"
+for category in SSH_KEY SSHKEY; do
+    rm -f "$op_edit_called"
+    out=$(printf '%s' 'dummy-secret' |
+        PATH="${op_bin}:${PATH}" OP_FIXTURE_CATEGORY="$category" \
+            OP_EDIT_CALLED="$op_edit_called" VAULT=test ITEM=test FIELD=password \
+            ./scripts/secret-set-1p.sh 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        fail "secret:set:1p accepted unsupported category $category"
+    fi
+    case "$out" in
+    *"item holds a passkey or SSH key"*) ;;
+    *) fail "secret:set:1p rejected $category for the wrong reason: $out" ;;
+    esac
+    if [ -e "$op_edit_called" ]; then
+        fail "secret:set:1p attempted an item edit for $category"
+    fi
+done
 
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/scripts/verify-codeql-result.sh
+++ b/scripts/verify-codeql-result.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fail closed unless CodeQL ran or skipped exactly as selected by the public/
+# paid-private scan decision and the fork trust boundary.
+set -euo pipefail
+
+scan="${FULL_SECURITY_SCAN-}"
+is_fork="${IS_FORK-}"
+result="${ANALYZE_RESULT-}"
+
+# Unset/empty means the optional private scan is disabled. Public workflows
+# pass true explicitly because CodeQL is automatic and required there.
+if [ -z "$scan" ]; then
+    scan=false
+fi
+
+case "$scan" in
+true | false) ;;
+*)
+    echo "Invalid FULL_SECURITY_SCAN value: ${scan:-<empty>} (expected true or false)" >&2
+    exit 1
+    ;;
+esac
+
+case "$is_fork" in
+true | false) ;;
+*)
+    echo "Invalid fork decision: ${is_fork:-<empty>} (expected true or false)" >&2
+    exit 1
+    ;;
+esac
+
+case "$result" in
+success | failure | cancelled | skipped) ;;
+*)
+    echo "Invalid CodeQL analyze result: ${result:-<empty>}" >&2
+    exit 1
+    ;;
+esac
+
+expected=skipped
+if [ "$scan" = true ] && [ "$is_fork" = false ]; then
+    expected=success
+fi
+
+if [ "$result" != "$expected" ]; then
+    echo "CodeQL analyze result: $result (expected $expected; scan=$scan fork=$is_fork)" >&2
+    exit 1
+fi
+
+echo "CodeQL analyze: $result (scan=$scan fork=$is_fork)"

--- a/scripts/verify-required-results.sh
+++ b/scripts/verify-required-results.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify that every named CI leaf has the one result the caller expects.
+#
+# Fork aggregates deliberately do not invoke this repository-controlled file;
+# they perform the equivalent skipped-only check inline in the trusted workflow.
+set -euo pipefail
+
+expected="${EXPECTED_RESULT:-success}"
+case "$expected" in
+success | skipped) ;;
+*)
+    echo "Invalid expected CI result: ${expected}" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$#" -eq 0 ]; then
+    echo "At least one name=result pair is required." >&2
+    exit 2
+fi
+
+failed=0
+for pair in "$@"; do
+    case "$pair" in
+    *=*) ;;
+    *)
+        echo "Invalid CI result argument (expected name=result): ${pair}" >&2
+        failed=1
+        continue
+        ;;
+    esac
+
+    name="${pair%%=*}"
+    result="${pair#*=}"
+    if [ -z "$name" ] || [ -z "$result" ]; then
+        echo "Invalid CI result argument (name and result are required): ${pair}" >&2
+        failed=1
+    elif [ "$result" != "$expected" ]; then
+        echo "Job ${name} result: ${result} (expected ${expected})" >&2
+        failed=1
+    fi
+done
+
+if [ "$failed" -ne 0 ]; then
+    echo "One or more required jobs did not have the expected result." >&2
+    exit 1
+fi
+
+echo "All required jobs reported ${expected}."


### PR DESCRIPTION
## Summary\n\n- update the repository from harmon-init v4.0.0 to v4.1.1\n- preserve site-specific design lint, accessibility build, and Foreman customizations\n- sync frontend skills to harmon-devkit v0.7.2\n- enforce fail-closed build, devcontainer, and CodeQL aggregate contracts\n- align CodeQL coverage with first-party JavaScript/TypeScript and Python sources\n\n## Validation\n\n- task sync:skills\n- pnpm install --frozen-lockfile\n- task format\n- task verify\n- task security