### PR TITLE
docs: add repository status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ TypeScript, and standardized with
 
 Author: Evan Harmon
 
-[![Build](https://github.com/evanharmon1/evanharmon-site/actions/workflows/build.yml/badge.svg)](https://github.com/evanharmon1/evanharmon-site/actions/workflows/build.yml)
+[![Build](https://github.com/evanharmon1/evanharmon-site/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/evanharmon1/evanharmon-site/actions/workflows/build.yml)
+[![CodeQL](https://github.com/evanharmon1/evanharmon-site/actions/workflows/codeql.yml/badge.svg?branch=main&event=push)](https://github.com/evanharmon1/evanharmon-site/actions/workflows/codeql.yml)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fevanharmon.com&up_message=online&down_message=offline&label=website)](https://evanharmon.com)
+[![Release](https://img.shields.io/github/v/release/evanharmon1/evanharmon-site?sort=semver&display_name=tag)](https://github.com/evanharmon1/evanharmon-site/releases/latest)
+[![License](https://img.shields.io/github/license/evanharmon1/evanharmon-site)](./LICENSE)
 
 ## Setup & Installation
 


### PR DESCRIPTION
## What changed

- pin the Build badge to `main` push runs
- add CodeQL workflow status
- add live website reachability
- add latest GitHub release and MIT license badges

## Why

The README exposed only the generic Build workflow status. These badges provide a compact, accurate view of CI, SAST workflow health, site reachability, release state, and licensing without implying unsupported coverage or deployment guarantees.

## Impact

Documentation only. No runtime or deployment behavior changes.

## Verification

- `task check`
- `task verify`
- `task challenge` — clean
- `task review` — clean
- `task ci`
- rendered badge endpoints verified for website, release, and license values

## Second-model adjudication

| Finding | Classification | Evidence | Action |
|---|---|---|---|
| No material findings | Clean | Both adversarial and verification-checkpoint reviews matched the badge URLs to existing workflows, releases, website, and license | None |
