### PR TITLE
chore: freeze Copier lineage to the verified template commit

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v4.4.0
+_commit: 617a309bdf1743cb3e258eaf75deae234178a52d
 _src_path: https://github.com/evanharmon1/harmon-init
 bunch_add: false
 ci_runner: ubuntu-latest


### PR DESCRIPTION
## What

Rewrites `_commit` in `.copier-answers.yml` from the tag `v4.4.0` to the commit
that tag points at, `617a309bdf1743cb3e258eaf75deae234178a52d`. One line; nothing else changes.

## Why

Copier derives `_commit` from `git describe --tags --always`, so a released tag
wins over the peeled hash even when `--vcs-ref` was given one. That was fixed
forward in [harmon-devkit#139](https://github.com/evanharmon1/harmon-devkit/pull/139),
but the fix only applies to new renders — it cannot help a repo already
scaffolded.

A tag is mutable, so tag-only lineage is not proof of which commit produced this
repo. `mode-update.md`'s preflight therefore refuses to run on it without
`ACCEPT_LEGACY_BASELINE=true` plus maintainer approval, and that branch also
needs authenticated `gh`. Every `copier update` hits that gate until one of them
promotes the tuple. Freezing it now means the next update starts from immutable
lineage and skips both.

## Evidence

All four checks from the update-mode guard pass:

| Check | Result |
| --- | --- |
| `_src_path` is the canonical harmon-init URL | ✅ |
| local `refs/tags/v4.4.0` matches the object `git ls-remote` reports on origin (tag not moved) | ✅ |
| peels to `617a309bdf1743cb3e258eaf75deae234178a52d`, an ancestor of `origin/main` | ✅ |
| GitHub release `target_commitish` for `v4.4.0` equals that same commit | ✅ |

The release record is captured at publish time and is independent of git, so it
is the evidence a moved tag could not fake. It is **commit-valued**, not a branch
name — the strong case, not the weak one that would only prove which branch the
release was cut from.

## Safety

This records the same template state immutably; it does not move the repo to a
different template version. `_src_path` was already canonical, so the lineage
tuple stays coherent — this is not the "rewrite the path alone" hazard the skill
warns about.

Edited with a targeted line replacement rather than `yq -i`, which reflows
unrelated multi-line answers and would have produced a misleading diff.

## Verification

- `task check` — pass
- `task verify` — fails identically on clean `main` in this checkout (exit 201): the site app is not scaffolded, so `build` skips and `validate:jsonld` finds no `dist/`. Pre-existing and unrelated to a one-line YAML metadata change; CI runs against a built tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
