### PR TITLE
fix(deps): raise security floors for postcss and brace-expansion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,9 @@ settings:
 overrides:
   esbuild: '>=0.28.1'
   sharp@<0.35.0: 0.35.3
-  postcss@<8.5.18: '>=8.5.18'
-  brace-expansion@<5.0.8: '>=5.0.8'
-  minimatch@<10.2.5: '>=10.2.5'
+  postcss@<8.5.18: '>=8.5.18 <9'
+  brace-expansion@<5.0.8: '>=5.0.8 <6'
+  minimatch@<10.2.5: '>=10.2.5 <11'
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   esbuild: '>=0.28.1'
   sharp@<0.35.0: 0.35.3
+  postcss@<8.5.18: '>=8.5.18'
+  brace-expansion@<5.0.8: '>=5.0.8'
+  minimatch@<10.2.5: '>=10.2.5'
 
 importers:
 
@@ -1272,9 +1275,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1287,12 +1287,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1372,9 +1369,6 @@ packages:
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2198,9 +2192,6 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -2211,8 +2202,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2345,8 +2336,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3434,7 +3425,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.5
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3455,7 +3446,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.3.0
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4258,20 +4249,13 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.33: {}
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4341,8 +4325,6 @@ snapshots:
   commander@11.1.0: {}
 
   common-ancestor-path@2.0.0: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4519,7 +4501,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-compat-utils: 0.6.5(eslint@9.39.4(jiti@2.7.0))
       globals: 16.5.0
-      postcss: 8.5.15
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4568,7 +4550,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -5504,11 +5486,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
-
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   mrmime@2.0.1: {}
 
@@ -5516,7 +5494,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -5647,9 +5625,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6186,7 +6164,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rollup: 4.61.0
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,9 +21,29 @@ minimumReleaseAgeExclude:
 # Security floor: esbuild <0.28.1 allows arbitrary file reads via the dev server
 # on Windows (GHSA; pnpm audit + Snyk). Astro/Vite still resolve 0.27.x — force
 # the patched line until they catch up.
+#
+# postcss <=8.5.17 is path traversal in the previous source map
+# (GHSA-r28c-9q8g-f849) and brace-expansion <=5.0.7 is DoS via unbounded
+# expansion (GHSA-mh99-v99m-4gvg). Both are transitive-only — postcss via
+# postcss-selector-parser, brace-expansion via minimatch under
+# @typescript-eslint/eslint. Both advisories are `high`, so
+# `task security:audit` (pnpm audit --audit-level=high) fails without these
+# floors, and brace-expansion has no patched 1.x — 5.0.8 is the first fix.
+#
+# minimatch is pinned WITH brace-expansion, not independently: minimatch@3
+# does `module.exports = expand` (the v1 shape), so lifting brace-expansion
+# alone breaks eslint with `TypeError: expand is not a function`. minimatch
+# @10.2.5 is the first release that depends on brace-expansion@^5, so the two
+# overrides have to move together. Drop them as a pair, never one at a time.
+#
+# The ranges are version-keyed so each override becomes a no-op once the
+# parents resolve a patched version on their own.
 overrides:
   esbuild: '>=0.28.1'
   sharp@<0.35.0: 0.35.3
+  postcss@<8.5.18: '>=8.5.18'
+  brace-expansion@<5.0.8: '>=5.0.8'
+  minimatch@<10.2.5: '>=10.2.5'
 
 # Local customization (not from the harmon-init template): expose Astro's
 # transitive deps at the root node_modules so direct imports like

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,12 +38,18 @@ minimumReleaseAgeExclude:
 #
 # The ranges are version-keyed so each override becomes a no-op once the
 # parents resolve a patched version on their own.
+#
+# Each replacement range is capped at the tested major (`<9`, `<6`, `<11`). An
+# unbounded `>=` would let a future major in silently the next time the lockfile
+# is regenerated — and an override genuinely does cross majors regardless of the
+# parent's own constraint, which is exactly how minimatch@3 became 10 here.
+# Raising a cap means re-running `task verify` on the new major first.
 overrides:
   esbuild: '>=0.28.1'
   sharp@<0.35.0: 0.35.3
-  postcss@<8.5.18: '>=8.5.18'
-  brace-expansion@<5.0.8: '>=5.0.8'
-  minimatch@<10.2.5: '>=10.2.5'
+  postcss@<8.5.18: '>=8.5.18 <9'
+  brace-expansion@<5.0.8: '>=5.0.8 <6'
+  minimatch@<10.2.5: '>=10.2.5 <11'
 
 # Local customization (not from the harmon-init template): expose Astro's
 # transitive deps at the root node_modules so direct imports like


### PR DESCRIPTION
## What

Adds two version-keyed `overrides` in `pnpm-workspace.yaml` (plus the paired
`minimatch` lift) so `pnpm audit --audit-level=high` comes back clean.

| Package | Was | Now | Advisory |
| --- | --- | --- | --- |
| postcss | 8.5.15 | 8.5.23 | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — path traversal in previous source map |
| brace-expansion | 1.1.16 + 5.0.7 | 5.0.8 | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — DoS via unbounded expansion |
| minimatch | 3.1.5 | 10.2.5 | (not vulnerable — see below) |

## Why

`task security:audit` fails on the two `high` advisories, which fails the
aggregate `verify` gate. **This blocks every open PR in the repo**, including
#48 — that PR changes one line of `.copier-answers.yml` and cannot possibly
introduce a postcss advisory. `main` last ran CI green on 2026-07-24, before
these advisories were published.

Neither package is reachable from shipped code — postcss arrives via
`postcss-selector-parser`, brace-expansion via `minimatch` under
`@typescript-eslint`. But the gate is severity-based, not reachability-based, so
the repo stays red until they are patched. There is no patched 1.x line for
brace-expansion; **5.0.8 is the first fix**, per the advisory's
`first_patched_version`.

## Why minimatch moves too

This is the non-obvious part. Raising brace-expansion **alone** breaks lint:

```
TypeError: expand is not a function
    at Minimatch.braceExpand (minimatch@3.1.5/minimatch.js:271:10)
    at doMatch (@eslint+config-array@0.21.2/dist/cjs/index.cjs:422:13)
```

`minimatch@3` does `module.exports = expand` (the brace-expansion v1 shape),
while 5.x publishes a named `{ expand }` export. `minimatch@10.2.5` is the first
release that depends on `brace-expansion@^5`, so the two overrides have to move
as a pair. That constraint is recorded in a comment above the block so a future
cleanup doesn't drop one and reintroduce the break.

I hit this failure during verification rather than reasoning about it — the
first attempt used only the brace-expansion floor and `task verify` caught it.

## Verification

- `task verify` — pass
- `task build` — pass
- `task lint:eslint` — exit 0 (the check that caught the naive fix)
- `pnpm audit --audit-level=high` — **2 high → 0**; 4 low/moderate remain, below the gate
- Resolved tree contains only `postcss@8.5.23`, `brace-expansion@5.0.8`, `minimatch@10.2.5` — no stale copies

## Note on #44

[#44](https://github.com/evanharmon1/evanharmon-site/pull/44) (astro v7) is a
plausible-looking alternative route, but it does **not** fix this: brace-expansion
comes in through `@typescript-eslint`, which that PR does not touch. #44 also has
three confirmed P2 Codex findings (unpatched `@astrojs/mdx` peer, `engines.node`
below Astro 7's floor, and the Sätteri default-processor swap that would silently
drop `readingTime` from blog posts) — I verified and replied to each in-thread. It
needs work regardless; this PR is independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)