### PR TITLE
chore: rewrite GitHub SSH URLs to HTTPS in devcontainer

### DIFF
--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -43,7 +43,10 @@ fi
 # forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
 # bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
 # Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
-git config --global url."https://github.com/".insteadOf "git@github.com:"
+# insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
+# ("cannot overwrite multiple values") on re-run and would fail post-create.
+git config --global --unset-all url."https://github.com/".insteadOf || true
+git config --global --add url."https://github.com/".insteadOf "git@github.com:"
 git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
 
 echo "Git user: $(git config --global user.name)"

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -38,6 +38,14 @@ else
     echo "GitHub CLI is not authenticated; skipping gh auth setup."
 fi
 
+# Rewrite GitHub SSH URLs to HTTPS for fetch AND push: in-container git ops
+# never depend on an SSH agent (absent in bot containers; lockout-prone when
+# forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
+# bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
+# Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
+git config --global url."https://github.com/".insteadOf "git@github.com:"
+git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"
 gh auth status || true

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -45,7 +45,10 @@ fi
 # Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
 # insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
 # ("cannot overwrite multiple values") on re-run and would fail post-create.
-git config --global --unset-all url."https://github.com/".insteadOf || true
+# Unset with --fixed-value so only the two managed values are removed — a
+# whole-key --unset-all would delete user-defined aliases (e.g. github:).
+git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "git@github.com:" || true
+git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "ssh://git@github.com/" || true
 git config --global --add url."https://github.com/".insteadOf "git@github.com:"
 git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
 


### PR DESCRIPTION
## What

Backfills the platform git-transport policy into this repo's (drifted) devcontainer script snapshot — the same change as evanharmon1/harmon-devkit#225 and evanharmon1/harmon-init#500:

- `url.insteadOf` rewrites both GitHub SSH forms to HTTPS for fetch and push, so in-container git operations never depend on an SSH agent (absent in bot containers, lockout-prone when forwarded into human ones). The reset-then-add form keeps the lifecycle script idempotent across re-runs (the scalar-set form exits 5 on the second run — caught in review on the sibling PRs).
- HTTPS auth comes from gh (`GH_TOKEN`, existing `gh auth setup-git` path) in bot/Coder profiles, or VS Code's forwarded host credential helper on attach.

Refs evanharmon1/harmon-dotfiles#37 · policy: harmon-dotfiles ADR 0002 (evanharmon1/harmon-dotfiles#40)

## Verification

- `task verify` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)