### PR TITLE
fix: cover every GitHub SSH endpoint form in devcontainer rewrite

### DIFF
--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -40,8 +40,8 @@ fi
 
 # Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
 # git ops never depend on an SSH agent (absent in bot containers; lockout-
-# prone when forwarded into human ones). Covers the scp form, both ssh://
-# forms, and the explicit port-443 endpoint. HTTPS auth comes from gh
+# prone when forwarded into human ones). Covers the scp form (git@github.com:)
+# plus all three ssh:// forms, including the explicit port-443 endpoint. HTTPS auth comes from gh
 # (GH_TOKEN, above) in bot/Coder profiles, or VS Code's forwarded host
 # credential helper on attach. Mirrors the host dotfiles policy
 # (harmon-dotfiles ADR 0002).

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -38,19 +38,21 @@ else
     echo "GitHub CLI is not authenticated; skipping gh auth setup."
 fi
 
-# Rewrite GitHub SSH URLs to HTTPS for fetch AND push: in-container git ops
-# never depend on an SSH agent (absent in bot containers; lockout-prone when
-# forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
-# bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
-# Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
+# Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
+# git ops never depend on an SSH agent (absent in bot containers; lockout-
+# prone when forwarded into human ones). Covers the scp form, both ssh://
+# forms, and the explicit port-443 endpoint. HTTPS auth comes from gh
+# (GH_TOKEN, above) in bot/Coder profiles, or VS Code's forwarded host
+# credential helper on attach. Mirrors the host dotfiles policy
+# (harmon-dotfiles ADR 0002).
 # insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
 # ("cannot overwrite multiple values") on re-run and would fail post-create.
-# Unset with --fixed-value so only the two managed values are removed — a
+# Unset with --fixed-value so only the four managed values are removed — a
 # whole-key --unset-all would delete user-defined aliases (e.g. github:).
-git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "git@github.com:" || true
-git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "ssh://git@github.com/" || true
-git config --global --add url."https://github.com/".insteadOf "git@github.com:"
-git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+for ssh_form in "git@github.com:" "ssh://git@github.com/" "ssh://git@ssh.github.com:443/" "ssh://git@ssh.github.com/"; do
+    git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "$ssh_form" || true
+    git config --global --add url."https://github.com/".insteadOf "$ssh_form"
+done
 
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"


### PR DESCRIPTION
## What

Propagates the endpoint-coverage findings from harmon-devkit#225 (Codex P1 + P2 there): the devcontainer rewrite set now covers all four GitHub SSH URL forms — adding the explicit port-443 endpoint `ssh://git@ssh.github.com:443/` and bare `ssh://git@ssh.github.com/` — restructured as a fixed-value unset+add loop (idempotent across re-runs, preserves user-defined aliases; re-verified with a pre-seeded `github:` alias).

Refs evanharmon1/harmon-dotfiles#37 · mirrors harmon-devkit#225 (`e755cec`)

## Verification

- `task verify` green locally
- All four forms confirmed rewriting to `https://github.com/…` via `ls-remote --get-url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)